### PR TITLE
Replace extract icon with 'Build Diagram' text button

### DIFF
--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -234,40 +234,19 @@ Page {
             anchors.right: parent.right
             anchors.rightMargin: 12
             anchors.verticalCenter: parent.verticalCenter
-            width: 28
-            height: 28
-            radius: 14
+            width: extractLabel.implicitWidth + 20
+            height: 32
+            radius: 16
             color: util.IS_UI_DARK_MODE ? "#4495F7" : "#007AFF"
             visible: tabBar.currentIndex === 0
 
-            Canvas {
+            Text {
+                id: extractLabel
                 anchors.centerIn: parent
-                width: 14
-                height: 14
-                onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.clearRect(0, 0, width, height)
-                    ctx.strokeStyle = "white"
-                    ctx.lineWidth = 1.5
-                    ctx.lineCap = "round"
-                    // Arrow down
-                    ctx.beginPath()
-                    ctx.moveTo(7, 1)
-                    ctx.lineTo(7, 9)
-                    ctx.stroke()
-                    ctx.beginPath()
-                    ctx.moveTo(3.5, 6)
-                    ctx.lineTo(7, 10)
-                    ctx.lineTo(10.5, 6)
-                    ctx.stroke()
-                    // Tray
-                    ctx.beginPath()
-                    ctx.moveTo(1, 10)
-                    ctx.lineTo(1, 13)
-                    ctx.lineTo(13, 13)
-                    ctx.lineTo(13, 10)
-                    ctx.stroke()
-                }
+                text: "Build Diagram"
+                color: "white"
+                font.pixelSize: 13
+                font.weight: Font.Medium
             }
             MouseArea {
                 anchors.fill: parent


### PR DESCRIPTION
## Summary
- Replaced the cryptic 28x28 canvas-drawn down-arrow icon on the extract button with a readable "Build Diagram" pill-shaped text button
- Improves discoverability for new users who couldn't identify the icon's purpose
- Same functionality (calls `personalApp.extractFull()`), same color scheme, same positioning

## Details
- Width auto-sizes to text content (`extractLabel.implicitWidth + 20`)
- Height: 32px, radius: 16px (pill shape)
- White text on blue background, works in both light and dark mode
- PDP badge anchoring unchanged (still anchors to `extractButton.left`)

Closes patrickkidd/theapp#96

## Test plan
- [ ] Verify "Build Diagram" text button visible on Discuss tab header, right side
- [ ] Tap button and confirm it calls extractFull() (same behavior as before)
- [ ] Check PDP badge appears correctly to the left of the wider button
- [ ] Verify button appearance in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)