### PR TITLE
Voice input: press-and-hold (walkie-talkie) mic button

### DIFF
--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -1,6 +1,9 @@
 import base64
+import json
 import logging
+import os
 import pickle
+import tempfile
 from typing import Callable
 
 from btcopilot.schema import (
@@ -14,6 +17,7 @@ from btcopilot.schema import (
     DateCertainty,
 )
 from PyQt5.QtTextToSpeech import QTextToSpeech, QVoice
+from PyQt5.QtMultimedia import QAudioRecorder, QAudioEncoderSettings
 from pkdiagram.personal.commands import HandlePDPItem, PDPAction
 from pkdiagram.personal.settings import Settings
 from _pkdiagram import CUtil
@@ -28,6 +32,7 @@ from pkdiagram.pyqt import (
     pyqtSlot,
     QNetworkReply,
     QNetworkRequest,
+    QNetworkAccessManager,
     QQuickItem,
     QUrl,
     QMessageBox,
@@ -35,7 +40,7 @@ from pkdiagram.pyqt import (
     QUndoStack,
     QVariant,
 )
-from PyQt5.QtCore import QLocale
+from PyQt5.QtCore import QLocale, QByteArray
 from pkdiagram.app import Session, Analytics
 from pkdiagram.personal.models import Discussion
 from pkdiagram.server_types import Diagram
@@ -73,6 +78,10 @@ class PersonalAppController(QObject):
     ttsPlayingIndexChanged = pyqtSignal()
     ttsFinished = pyqtSignal()
     ttsVoiceChanged = pyqtSignal()
+
+    transcriptionReady = pyqtSignal(str, arguments=["text"])
+    transcriptionFailed = pyqtSignal(str, arguments=["error"])
+    recordingFailed = pyqtSignal(str, arguments=["error"])
 
     def __init__(self, undoStack=None, parent=None):
         super().__init__(parent)
@@ -113,6 +122,11 @@ class PersonalAppController(QObject):
         self._ttsPlayingIndex = -1
         self._tts.stateChanged.connect(self._onTtsStateChanged)
         self._initTtsVoice()
+
+        # Voice recording
+        self._audioRecorder = QAudioRecorder(self)
+        self._recordingFilePath = ""
+        self._networkManager = QNetworkAccessManager(self)
 
     def _initTtsVoice(self):
         saved = self._settings.value("ttsVoiceName")
@@ -399,6 +413,222 @@ class PersonalAppController(QObject):
                     "x-apple.systempreferences:com.apple.preference.universalaccess?SpokenContent",
                 ]
             )
+
+    # Voice Recording & Transcription
+
+    @pyqtSlot()
+    def startRecording(self):
+        """Start recording audio via QAudioRecorder."""
+        try:
+            tmpFile = tempfile.NamedTemporaryFile(
+                suffix=".wav", delete=False, prefix="fd_voice_"
+            )
+            self._recordingFilePath = tmpFile.name
+            tmpFile.close()
+
+            audioSettings = QAudioEncoderSettings()
+            audioSettings.setCodec("audio/pcm")
+            audioSettings.setSampleRate(16000)
+            audioSettings.setChannelCount(1)
+
+            self._audioRecorder.setEncodingSettings(audioSettings)
+            self._audioRecorder.setOutputLocation(
+                QUrl.fromLocalFile(self._recordingFilePath)
+            )
+            self._audioRecorder.record()
+            _log.info(f"Started recording to {self._recordingFilePath}")
+        except Exception as e:
+            _log.error(f"Failed to start recording: {e}")
+            self.recordingFailed.emit(str(e))
+
+    @pyqtSlot()
+    def cancelRecording(self):
+        """Stop recording WITHOUT transcribing (e.g. short tap or drag-off)."""
+        self._audioRecorder.stop()
+        _log.info(f"Cancelled recording: {self._recordingFilePath}")
+        self._cleanupRecording(self._recordingFilePath)
+        self._recordingFilePath = ""
+
+    @pyqtSlot()
+    def stopRecording(self):
+        """Stop recording and begin transcription."""
+        self._audioRecorder.stop()
+        _log.info(f"Stopped recording: {self._recordingFilePath}")
+
+        if not self._recordingFilePath or not os.path.exists(self._recordingFilePath):
+            self.transcriptionFailed.emit("Recording file not found")
+            return
+
+        self._transcribeAudio(self._recordingFilePath)
+
+    def _getAssemblyAIKey(self) -> str:
+        """Get AssemblyAI API key from environment or server config."""
+        key = os.environ.get("ASSEMBLYAI_API_KEY", "")
+        if not key:
+            key = self._settings.value("assemblyaiApiKey", "")
+        return key
+
+    def _transcribeAudio(self, filePath: str):
+        """Upload audio to AssemblyAI and poll for transcription result."""
+        apiKey = self._getAssemblyAIKey()
+        if not apiKey:
+            self.transcriptionFailed.emit(
+                "AssemblyAI API key not configured. Set ASSEMBLYAI_API_KEY environment variable."
+            )
+            self._cleanupRecording(filePath)
+            return
+
+        # Step 1: Upload the audio file
+        try:
+            with open(filePath, "rb") as f:
+                audioData = f.read()
+        except Exception as e:
+            _log.error(f"Failed to read recording file: {e}")
+            self.transcriptionFailed.emit(f"Failed to read recording: {e}")
+            self._cleanupRecording(filePath)
+            return
+
+        uploadRequest = QNetworkRequest(QUrl("https://api.assemblyai.com/v2/upload"))
+        uploadRequest.setRawHeader(
+            QByteArray(b"authorization"), QByteArray(apiKey.encode())
+        )
+        uploadRequest.setRawHeader(
+            QByteArray(b"content-type"), QByteArray(b"application/octet-stream")
+        )
+
+        uploadReply = self._networkManager.post(uploadRequest, QByteArray(audioData))
+        uploadReply.finished.connect(
+            lambda: self._onUploadFinished(uploadReply, apiKey, filePath)
+        )
+
+    def _onUploadFinished(self, reply: QNetworkReply, apiKey: str, filePath: str):
+        """Handle upload response, then submit for transcription."""
+        error = reply.error()
+        if error != QNetworkReply.NoError:
+            errorMsg = reply.errorString()
+            _log.error(f"Audio upload failed: {errorMsg}")
+            self.transcriptionFailed.emit(f"Upload failed: {errorMsg}")
+            reply.deleteLater()
+            self._cleanupRecording(filePath)
+            return
+
+        responseData = json.loads(bytes(reply.readAll()))
+        reply.deleteLater()
+        uploadUrl = responseData.get("upload_url", "")
+
+        if not uploadUrl:
+            self.transcriptionFailed.emit("Upload succeeded but no URL returned")
+            self._cleanupRecording(filePath)
+            return
+
+        _log.info(f"Audio uploaded: {uploadUrl}")
+
+        # Step 2: Submit transcription request
+        transcriptRequest = QNetworkRequest(
+            QUrl("https://api.assemblyai.com/v2/transcript")
+        )
+        transcriptRequest.setRawHeader(
+            QByteArray(b"authorization"), QByteArray(apiKey.encode())
+        )
+        transcriptRequest.setRawHeader(
+            QByteArray(b"content-type"), QByteArray(b"application/json")
+        )
+
+        requestBody = json.dumps({"audio_url": uploadUrl}).encode()
+        transcriptReply = self._networkManager.post(
+            transcriptRequest, QByteArray(requestBody)
+        )
+        transcriptReply.finished.connect(
+            lambda: self._onTranscriptSubmitted(transcriptReply, apiKey, filePath)
+        )
+
+    def _onTranscriptSubmitted(
+        self, reply: QNetworkReply, apiKey: str, filePath: str
+    ):
+        """Handle transcription submission, then start polling."""
+        error = reply.error()
+        if error != QNetworkReply.NoError:
+            errorMsg = reply.errorString()
+            _log.error(f"Transcription request failed: {errorMsg}")
+            self.transcriptionFailed.emit(f"Transcription request failed: {errorMsg}")
+            reply.deleteLater()
+            self._cleanupRecording(filePath)
+            return
+
+        responseData = json.loads(bytes(reply.readAll()))
+        reply.deleteLater()
+        transcriptId = responseData.get("id", "")
+
+        if not transcriptId:
+            self.transcriptionFailed.emit("No transcript ID returned")
+            self._cleanupRecording(filePath)
+            return
+
+        _log.info(f"Transcription submitted: {transcriptId}")
+        self._pollTranscription(transcriptId, apiKey, filePath)
+
+    def _pollTranscription(self, transcriptId: str, apiKey: str, filePath: str):
+        """Poll AssemblyAI for transcription completion."""
+        from PyQt5.QtCore import QTimer
+
+        pollUrl = QUrl(f"https://api.assemblyai.com/v2/transcript/{transcriptId}")
+        pollRequest = QNetworkRequest(pollUrl)
+        pollRequest.setRawHeader(
+            QByteArray(b"authorization"), QByteArray(apiKey.encode())
+        )
+
+        pollReply = self._networkManager.get(pollRequest)
+        pollReply.finished.connect(
+            lambda: self._onPollFinished(pollReply, transcriptId, apiKey, filePath)
+        )
+
+    def _onPollFinished(
+        self,
+        reply: QNetworkReply,
+        transcriptId: str,
+        apiKey: str,
+        filePath: str,
+    ):
+        """Handle poll response; re-poll if still processing."""
+        from PyQt5.QtCore import QTimer
+
+        error = reply.error()
+        if error != QNetworkReply.NoError:
+            errorMsg = reply.errorString()
+            _log.error(f"Transcription poll failed: {errorMsg}")
+            self.transcriptionFailed.emit(f"Poll failed: {errorMsg}")
+            reply.deleteLater()
+            self._cleanupRecording(filePath)
+            return
+
+        responseData = json.loads(bytes(reply.readAll()))
+        reply.deleteLater()
+        status = responseData.get("status", "")
+
+        if status == "completed":
+            text = responseData.get("text", "")
+            _log.info(f"Transcription completed: {text[:80]}...")
+            self.transcriptionReady.emit(text)
+            self._cleanupRecording(filePath)
+        elif status == "error":
+            errorMsg = responseData.get("error", "Unknown transcription error")
+            _log.error(f"Transcription error: {errorMsg}")
+            self.transcriptionFailed.emit(errorMsg)
+            self._cleanupRecording(filePath)
+        else:
+            # Still processing — poll again after 1 second
+            QTimer.singleShot(
+                1000, lambda: self._pollTranscription(transcriptId, apiKey, filePath)
+            )
+
+    def _cleanupRecording(self, filePath: str):
+        """Remove temporary recording file."""
+        try:
+            if filePath and os.path.exists(filePath):
+                os.unlink(filePath)
+                _log.debug(f"Cleaned up recording file: {filePath}")
+        except Exception as e:
+            _log.warning(f"Failed to clean up recording file: {e}")
 
     # Diagram
 

--- a/pkdiagram/resources/qml/Personal/DiscussView.qml
+++ b/pkdiagram/resources/qml/Personal/DiscussView.qml
@@ -23,6 +23,7 @@ Page {
     property var chatModel: chatModel
     property var textEdit: textEdit
     property var submitButton: sendButton
+    property var micButton: micButton
     property var noChatLabel: noChatLabel
     property var statementsList: statementsList
     property var pdpSheet: pdpSheet
@@ -43,8 +44,30 @@ Page {
 
     property bool initSelectedDiscussion: false
 
+    // Voice recording states: "idle", "recording", "transcribing"
+    property string voiceState: "idle"
+    // Timestamp when recording started (for minimum duration check)
+    property real recordingStartTime: 0
+    // Minimum hold duration in ms before recording is accepted
+    readonly property int minRecordingDurationMs: 300
+
     Connections {
         target: personalApp
+        function onTranscriptionReady(text) {
+            root.voiceState = "idle"
+            if (text.length > 0) {
+                textEdit.text = text
+                textEdit.forceActiveFocus()
+            }
+        }
+        function onTranscriptionFailed(error) {
+            root.voiceState = "idle"
+            util.criticalBox("Transcription Failed", error)
+        }
+        function onRecordingFailed(error) {
+            root.voiceState = "idle"
+            util.criticalBox("Recording Failed", error)
+        }
         function onDiscussionsChanged() {
             if (!initSelectedDiscussion) {
                 initSelectedDiscussion = true
@@ -451,11 +474,11 @@ Page {
                     id: inputFlickable
                     anchors {
                         left: parent.left
-                        right: sendButton.visible ? sendButton.left : parent.right
+                        right: sendButton.visible ? sendButton.left : micButton.left
                         top: parent.top
                         bottom: parent.bottom
                         leftMargin: 12
-                        rightMargin: sendButton.visible ? 4 : 12
+                        rightMargin: 4
                         topMargin: 4
                         bottomMargin: 4
                     }
@@ -573,6 +596,159 @@ Page {
                         anchors.fill: parent
                         cursorShape: Qt.PointingHandCursor
                         onClicked: inputField.submit()
+                    }
+                }
+
+                // Microphone button for voice input
+                Rectangle {
+                    id: micButton
+                    objectName: "micButton"
+                    visible: !sendButton.visible
+                    anchors {
+                        right: parent.right
+                        verticalCenter: parent.verticalCenter
+                        rightMargin: 4
+                    }
+                    width: 28
+                    height: 28
+                    radius: 14
+                    color: root.voiceState === "recording" ? "#FF3B30" : "transparent"
+
+                    // Pulsing animation when recording
+                    SequentialAnimation on opacity {
+                        id: pulseAnim
+                        running: root.voiceState === "recording"
+                        loops: Animation.Infinite
+                        NumberAnimation { to: 0.5; duration: 600; easing.type: Easing.InOutQuad }
+                        NumberAnimation { to: 1.0; duration: 600; easing.type: Easing.InOutQuad }
+                        onRunningChanged: {
+                            if (!running) micButton.opacity = 1.0
+                        }
+                    }
+
+                    // Microphone icon (idle + recording)
+                    Canvas {
+                        id: micIcon
+                        anchors.centerIn: parent
+                        width: 16
+                        height: 16
+                        visible: root.voiceState !== "transcribing"
+                        onPaint: {
+                            var ctx = getContext("2d")
+                            ctx.clearRect(0, 0, width, height)
+                            var color = root.voiceState === "recording" ? "white" : root.chatPlaceholder
+                            ctx.fillStyle = color
+                            ctx.strokeStyle = color
+                            ctx.lineWidth = 1.2
+
+                            // Mic body (rounded rect)
+                            var mw = 5, mh = 8, mx = (width - mw) / 2, my = 1
+                            ctx.beginPath()
+                            ctx.moveTo(mx + 1.5, my)
+                            ctx.lineTo(mx + mw - 1.5, my)
+                            ctx.quadraticCurveTo(mx + mw, my, mx + mw, my + 1.5)
+                            ctx.lineTo(mx + mw, my + mh - 1.5)
+                            ctx.quadraticCurveTo(mx + mw, my + mh, mx + mw - 1.5, my + mh)
+                            ctx.lineTo(mx + 1.5, my + mh)
+                            ctx.quadraticCurveTo(mx, my + mh, mx, my + mh - 1.5)
+                            ctx.lineTo(mx, my + 1.5)
+                            ctx.quadraticCurveTo(mx, my, mx + 1.5, my)
+                            ctx.closePath()
+                            ctx.fill()
+
+                            // Arc around mic
+                            ctx.beginPath()
+                            ctx.arc(width / 2, 6, 5.5, 0, Math.PI, false)
+                            ctx.stroke()
+
+                            // Stem
+                            ctx.beginPath()
+                            ctx.moveTo(width / 2, 11.5)
+                            ctx.lineTo(width / 2, 14)
+                            ctx.stroke()
+
+                            // Base
+                            ctx.beginPath()
+                            ctx.moveTo(width / 2 - 2.5, 14)
+                            ctx.lineTo(width / 2 + 2.5, 14)
+                            ctx.stroke()
+                        }
+                        // Repaint when voice state changes
+                        Connections {
+                            target: root
+                            function onVoiceStateChanged() { micIcon.requestPaint() }
+                        }
+                    }
+
+                    // Spinner when transcribing
+                    Rectangle {
+                        id: spinner
+                        anchors.centerIn: parent
+                        width: 14
+                        height: 14
+                        radius: 7
+                        color: "transparent"
+                        border.width: 2
+                        border.color: root.chatPlaceholder
+                        visible: root.voiceState === "transcribing"
+
+                        // Spinning arc overlay
+                        Canvas {
+                            anchors.fill: parent
+                            visible: root.voiceState === "transcribing"
+                            property real angle: 0
+                            onPaint: {
+                                var ctx = getContext("2d")
+                                ctx.clearRect(0, 0, width, height)
+                                ctx.strokeStyle = root.chatButton
+                                ctx.lineWidth = 2
+                                ctx.lineCap = "round"
+                                ctx.beginPath()
+                                ctx.arc(width / 2, height / 2, 5, angle, angle + Math.PI * 0.75)
+                                ctx.stroke()
+                            }
+                            NumberAnimation on angle {
+                                from: 0
+                                to: Math.PI * 2
+                                duration: 1000
+                                loops: Animation.Infinite
+                                running: root.voiceState === "transcribing"
+                            }
+                            onAngleChanged: requestPaint()
+                        }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onPressed: {
+                            if (root.voiceState === "idle") {
+                                root.recordingStartTime = Date.now()
+                                root.voiceState = "recording"
+                                personalApp.startRecording()
+                            }
+                            // Do nothing if transcribing - wait for result
+                        }
+                        onReleased: {
+                            if (root.voiceState === "recording") {
+                                var elapsed = Date.now() - root.recordingStartTime
+                                if (elapsed < root.minRecordingDurationMs) {
+                                    // Too short - discard without transcribing
+                                    root.voiceState = "idle"
+                                    personalApp.cancelRecording()
+                                } else {
+                                    root.voiceState = "transcribing"
+                                    personalApp.stopRecording()
+                                }
+                            }
+                        }
+                        onCanceled: {
+                            // Finger dragged off the button - discard
+                            if (root.voiceState === "recording") {
+                                root.voiceState = "idle"
+                                personalApp.cancelRecording()
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Supersedes PR #118 — changes mic button from tap-to-toggle to **press-and-hold** (walkie-talkie style)
- **Press and hold** the mic button to record, **release** to stop and transcribe
- Short taps (<300ms) are discarded without transcription
- Finger drag-off cancels recording cleanly via `onCanceled`
- New `cancelRecording()` backend slot stops QAudioRecorder without triggering transcription pipeline

## Changes
- **DiscussView.qml**: `onClicked` → `onPressed`/`onReleased`/`onCanceled`, added `recordingStartTime` and `minRecordingDurationMs` properties
- **personalappcontroller.py**: Added `cancelRecording()` pyqtSlot that stops recorder and cleans up temp file

## Test plan
- [ ] Press and hold mic button → verify recording state (red pulsing)
- [ ] Release after >300ms → verify transcribing state (spinner), then text populates input
- [ ] Quick tap (<300ms) → verify recording is discarded, returns to idle
- [ ] Press and drag finger off button → verify recording is cancelled
- [ ] Verify mic button appears when text input is empty
- [ ] Verify send button replaces mic button when text is entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)