### PR TITLE
Fix CI: add QtMultimedia support for PR #118

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ./sysroot/sysroot-macos-64
-        key: sysroot-macos-64-15-intel-64-5.15.16--3.11.6
+        key: sysroot-macos-64-15-intel-64-5.15.16--3.11.6-v2
         # key: sysroot-${{ runner.os }}-${{ hashFiles('./sysroot/sysroot.toml') }}
 
 
@@ -159,7 +159,7 @@ jobs:
       if: steps.cache-sysroot.outputs.cache-hit != 'true'
       with:
         path: ./sysroot/sysroot-macos-64
-        key: sysroot-macos-64-15-intel-64-5.15.16--3.11.6
+        key: sysroot-macos-64-15-intel-64-5.15.16--3.11.6-v2
 
     - name: pyqtdeploy-build
       run: |
@@ -362,7 +362,7 @@ jobs:
         run: |
           call .venv\Scripts\activate.bat
           pip install aqtinstall
-          aqt install-qt windows desktop 5.15.2 win64_msvc2019_64 --outputdir C:\Qt --archives qtbase qtdeclarative qtgraphicaleffects qtimageformats qtquickcontrols qtquickcontrols2 qttools qtwinextras
+          aqt install-qt windows desktop 5.15.2 win64_msvc2019_64 --outputdir C:\Qt --archives qtbase qtdeclarative qtgraphicaleffects qtimageformats qtquickcontrols qtquickcontrols2 qttools qtwinextras qtmultimedia
         shell: cmd
         
       - name: Setup MSVC (x64)
@@ -519,7 +519,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: sysroot/sysroot-win-64
-          key: sysroot-win-64-5.15.16--3.11.6
+          key: sysroot-win-64-5.15.16--3.11.6-v2
           # key: sysroot-${{ runner.os }}-${{ hashFiles('./sysroot/sysroot.toml') }}
   
       # The moc files are required by the sysroot plugin as well as the build plugin
@@ -552,7 +552,7 @@ jobs:
         if: steps.cache-sysroot.outputs.cache-hit != 'true'
         with:
           path: sysroot/sysroot-win-64
-          key: sysroot-win-64-5.15.16--3.11.6
+          key: sysroot-win-64-5.15.16--3.11.6-v2
   
       - name: Write build config
         run: |


### PR DESCRIPTION
## Summary
- Add `qtmultimedia` to Windows `aqt install-qt` archives so the Qt Multimedia module is available at build time
- Bust sysroot cache keys (macOS + Windows) with `-v2` suffix so they rebuild with qtmultimedia included (PR #118 removed `qtmultimedia` from the skip list in `sysroot.toml`)

Unblocks #118 (voice input feature) which depends on `QAudioRecorder` from QtMultimedia.

## Context
PR #118 added `QtMultimedia` to `sysroot.toml` and `familydiagram.pdt`, but CI failed with:
```
Project ERROR: Unknown module(s) in QT: multimedia
```
because:
1. The Windows host Qt (installed via aqt) didn't include the multimedia archive
2. Both macOS and Windows sysroot caches were stale — built before qtmultimedia was added, and the cache keys are hardcoded (not hash-based) so they didn't invalidate

## Test plan
- [ ] CI build-osx passes qmake step without "Unknown module(s) in QT: multimedia"
- [ ] CI build-windows passes qmake step without "Unknown module(s) in QT: multimedia"
- [ ] After merge, rebase PR #118 and verify its CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)