### PR TITLE
Add confidence-based visual rendering to PDP cards

### DIFF
--- a/pkdiagram/resources/qml/Personal/PDPEventCard.qml
+++ b/pkdiagram/resources/qml/Personal/PDPEventCard.qml
@@ -11,6 +11,9 @@ Rectangle {
     property var eventData
     property var pdp
 
+    readonly property real confidenceOpacity: Math.max(0.4, eventData && eventData.confidence !== null && eventData.confidence !== undefined ? eventData.confidence : 0.7)
+    readonly property bool lowConfidence: eventData && eventData.confidence !== null && eventData.confidence !== undefined && eventData.confidence < 0.5
+
     signal accepted(int id)
     signal rejected(int id)
     signal editRequested(var eventData)
@@ -76,6 +79,19 @@ Rectangle {
         return dt
     }
 
+    // Low-confidence indicator
+    Text {
+        visible: root.lowConfidence
+        text: "?"
+        font.pixelSize: 10
+        color: util.IS_UI_DARK_MODE ? '#888' : '#999'
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 6
+        anchors.rightMargin: 8
+        z: 1
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 12
@@ -84,6 +100,7 @@ Rectangle {
         RowLayout {
             Layout.fillWidth: true
             spacing: 8
+            opacity: root.confidenceOpacity
 
             Rectangle {
                 Layout.preferredWidth: 70
@@ -131,11 +148,13 @@ Rectangle {
             Layout.fillWidth: true
             height: 1
             color: util.QML_ITEM_BORDER_COLOR
+            opacity: root.confidenceOpacity
         }
 
         Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            opacity: root.confidenceOpacity
 
             // Intercept all wheel events so the Flickable doesn't swallow
             // horizontal ones. Vertical: forward to Flickable. Horizontal:
@@ -406,12 +425,14 @@ Rectangle {
             Layout.fillWidth: true
             height: 1
             color: util.QML_ITEM_BORDER_COLOR
+            opacity: root.confidenceOpacity
         }
 
         RowLayout {
             Layout.fillWidth: true
             Layout.preferredHeight: 36
             spacing: 8
+            // Buttons stay at full opacity for tappability
 
             PK.Button {
                 id: rejectButton

--- a/pkdiagram/resources/qml/Personal/PDPEventCard.qml
+++ b/pkdiagram/resources/qml/Personal/PDPEventCard.qml
@@ -11,8 +11,9 @@ Rectangle {
     property var eventData
     property var pdp
 
-    readonly property real confidenceOpacity: Math.max(0.4, eventData && eventData.confidence !== null && eventData.confidence !== undefined ? eventData.confidence : 0.7)
-    readonly property bool lowConfidence: eventData && eventData.confidence !== null && eventData.confidence !== undefined && eventData.confidence < 0.5
+    readonly property real _effectiveConfidence: eventData && eventData.confidence !== null && eventData.confidence !== undefined ? eventData.confidence : 0.7
+    readonly property real confidenceOpacity: Math.max(0.4, _effectiveConfidence)
+    readonly property bool lowConfidence: _effectiveConfidence < 0.5
 
     signal accepted(int id)
     signal rejected(int id)

--- a/pkdiagram/resources/qml/Personal/PDPPersonCard.qml
+++ b/pkdiagram/resources/qml/Personal/PDPPersonCard.qml
@@ -11,8 +11,9 @@ Rectangle {
     property var personData
     property var pdp
 
-    readonly property real confidenceOpacity: Math.max(0.4, personData && personData.confidence !== null && personData.confidence !== undefined ? personData.confidence : 0.7)
-    readonly property bool lowConfidence: personData && personData.confidence !== null && personData.confidence !== undefined && personData.confidence < 0.5
+    readonly property real _effectiveConfidence: personData && personData.confidence !== null && personData.confidence !== undefined ? personData.confidence : 0.7
+    readonly property real confidenceOpacity: Math.max(0.4, _effectiveConfidence)
+    readonly property bool lowConfidence: _effectiveConfidence < 0.5
 
     signal accepted(int id)
     signal rejected(int id)

--- a/pkdiagram/resources/qml/Personal/PDPPersonCard.qml
+++ b/pkdiagram/resources/qml/Personal/PDPPersonCard.qml
@@ -11,6 +11,9 @@ Rectangle {
     property var personData
     property var pdp
 
+    readonly property real confidenceOpacity: Math.max(0.4, personData && personData.confidence !== null && personData.confidence !== undefined ? personData.confidence : 0.7)
+    readonly property bool lowConfidence: personData && personData.confidence !== null && personData.confidence !== undefined && personData.confidence < 0.5
+
     signal accepted(int id)
     signal rejected(int id)
     signal editRequested(var personData)
@@ -21,6 +24,19 @@ Rectangle {
     border.color: util.QML_ITEM_BORDER_COLOR
     border.width: 1
 
+    // Low-confidence indicator
+    Text {
+        visible: root.lowConfidence
+        text: "?"
+        font.pixelSize: 10
+        color: util.IS_UI_DARK_MODE ? '#888' : '#999'
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 6
+        anchors.rightMargin: 8
+        z: 1
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 12
@@ -29,6 +45,7 @@ Rectangle {
         RowLayout {
             Layout.fillWidth: true
             spacing: 8
+            opacity: root.confidenceOpacity
 
             Rectangle {
                 Layout.preferredWidth: 28
@@ -81,11 +98,13 @@ Rectangle {
             Layout.fillWidth: true
             height: 1
             color: util.QML_ITEM_BORDER_COLOR
+            opacity: root.confidenceOpacity
         }
 
         Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            opacity: root.confidenceOpacity
 
             MouseArea {
                 anchors.fill: parent
@@ -192,12 +211,14 @@ Rectangle {
             Layout.fillWidth: true
             height: 1
             color: util.QML_ITEM_BORDER_COLOR
+            opacity: root.confidenceOpacity
         }
 
         RowLayout {
             Layout.fillWidth: true
             Layout.preferredHeight: 36
             spacing: 8
+            // Buttons stay at full opacity for tappability
 
             PK.Button {
                 id: rejectButton


### PR DESCRIPTION
## Summary
- PDP person and event cards now visually reflect AI extraction confidence levels
- Card content (header, fields, separators) fades based on confidence value (opacity 0.4–1.0, default 0.7 when unset)
- Items with confidence < 0.5 display a '?' indicator in the top-right corner (dark/light mode aware)
- Accept/Reject buttons remain at full opacity so they stay tappable regardless of card confidence

## Test plan
- [ ] Verify PDP items with confidence=0.9+ render at full opacity
- [ ] Verify PDP items with confidence=0.3 render noticeably faded (~0.4 opacity)
- [ ] Verify items with confidence < 0.5 show '?' indicator
- [ ] Verify Accept/Reject buttons remain fully opaque and functional
- [ ] Verify items without confidence value default to 0.7 opacity
- [ ] Verify rendering in both light and dark mode

Closes patrickkidd/theapp#102

🤖 Generated with [Claude Code](https://claude.com/claude-code)