### PR TITLE
Fix timeline initial zoom and right-edge overflow (#87)

### DIFF
--- a/pkdiagram/resources/qml/Personal/LearnView.qml
+++ b/pkdiagram/resources/qml/Personal/LearnView.qml
@@ -131,9 +131,22 @@ Page {
         }
         return maxVal === -Infinity ? (sarfGraphModel ? sarfGraphModel.yearEnd : 2025) : maxVal
     }
-    property real _clusterPad: Math.max(0.25, (_clusterMaxRaw - _clusterMinRaw) * 0.05)
-    property real clusterMinYearFrac: _clusterMinRaw - _clusterPad
-    property real clusterMaxYearFrac: _clusterMaxRaw + _clusterPad
+    property real _clusterPadBase: Math.max(0.25, (_clusterMaxRaw - _clusterMinRaw) * 0.05)
+    // Extra right padding so the last cluster bar (with minBarWidth) doesn't overflow.
+    // At zoom 1.0: minBarWidth pixels = (minBarYears / totalSpan) * gWidth,
+    // so minBarYears = minBarWidth / gWidth * totalSpan. Use iterative estimate.
+    property real _clusterPadRight: {
+        var rawSpan = _clusterMaxRaw - _clusterMinRaw
+        if (rawSpan <= 0 || gWidth <= 0) return _clusterPadBase
+        // First estimate total span with base padding on both sides
+        var estimatedSpan = rawSpan + _clusterPadBase * 2
+        // How many year-fracs does minBarWidth represent at zoom 1.0?
+        var minBarYears = (minBarWidth / gWidth) * estimatedSpan
+        // Right padding = base + enough room for the widest minBarWidth cluster at the edge
+        return _clusterPadBase + minBarYears
+    }
+    property real clusterMinYearFrac: _clusterMinRaw - _clusterPadBase
+    property real clusterMaxYearFrac: _clusterMaxRaw + _clusterPadRight
     property real clusterYearSpan: Math.max(1, clusterMaxYearFrac - clusterMinYearFrac)
 
     background: Rectangle {


### PR DESCRIPTION
## Summary
- **Fixed right-edge overflow**: Last cluster bar no longer runs off the right side of the viewport. The symmetric 5% padding was insufficient because `minBarWidth` (30px) expands narrow clusters beyond their proportional year-range width. Now uses asymmetric padding — left side keeps base 5% padding, right side dynamically adds extra space proportional to `minBarWidth` at the current viewport scale.
- **Fixed initial zoom**: At zoom 1.0 (the default), all cluster bars now fit within the viewport on first load. No code change to `applyOptimalZoom()` was needed — the padding fix ensures zoom 1.0 correctly contains all bars.

## Details
The root cause was that `_clusterPad` applied identical padding on both sides (5% of year range, min 0.25 years). When the rightmost cluster had a short time span, `minBarWidth` forced its bar to 30px wide, pushing it past `gWidth`. The fix computes how many year-fractions `minBarWidth` represents at the current scale and adds that to the right padding.

## Test plan
- [ ] Load a discussion with 5+ clusters → timeline should fit all clusters at initial zoom
- [ ] Last cluster fully visible, no horizontal overflow
- [ ] User can still pinch/wheel zoom and drag-pan after load
- [ ] Reset zoom button still works
- [ ] Single-day clusters (narrow bars) remain tappable and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)