### PR TITLE
Fix baseline view not rendering in new diagrams (#84)

### DIFF
--- a/doc/asbuilts/LEARN_VIEW.md
+++ b/doc/asbuilts/LEARN_VIEW.md
@@ -189,6 +189,18 @@ This means: if an event is expanded, the ring follows it; otherwise the ring fol
 
 ## Recent Changes
 
+### 2026-03-11: Baseline View for New Diagrams (Issue #84)
+- **Issue**: In newly created diagrams, the LearnView graph area was blank because `showClusters` defaults to `true` but no clusters have been detected yet. Event dots were hidden (only shown when `!showClusters`), cluster bars container was visible but empty, and `graphCanvas` drew nothing.
+- **Root cause**: No fallback rendering when clusters are enabled but none exist. The code assumed clusters would always be available when `showClusters` was true.
+- **Fix**: Added `showBaselineView` property (`true` when `!hasClusters`). When active:
+  1. Draws cumulative SARF lines (symptom/anxiety/functioning) on the overview graph canvas
+  2. Shows event dot markers on the graph (same as raw data mode)
+  3. Draws a baseline zero-reference line
+  4. Hides the empty cluster bars container
+  5. Enables zoom/pan interactions that were previously only active in raw data mode
+- **Behavior**: Automatically transitions to cluster view once clusters are detected (AI async). No user action needed.
+- **Impact**: New diagrams immediately show SARF data visualization instead of a blank graph
+
 ### 2026-01-31: Relationship Line Click Detection
 - **Issue**: Clicking on the vertical blue relationship event lines in the graph didn't select those events
 - **Fix**: Added relationship line click detection in hero graph click handler - checks X distance to relationship lines (threshold: 20px)

--- a/pkdiagram/resources/qml/Personal/LearnView.qml
+++ b/pkdiagram/resources/qml/Personal/LearnView.qml
@@ -815,16 +815,7 @@ Page {
                 color: util.IS_UI_DARK_MODE ? "#151520" : "#f5f5fa"
             }
 
-            // Baseline zero-line (shown in baseline view when SARF data exists)
-            Rectangle {
-                visible: showBaselineView && !isFocused && sarfGraphModel && sarfGraphModel.hasData
-                x: gLeft; y: yPosMini(0)
-                width: gWidth; height: 1
-                color: dividerColor
-                opacity: 0.5
-            }
-
-            // Graph lines
+            // Graph lines (baseline zero-line is drawn inside the canvas onPaint handler)
             Canvas {
                 id: graphCanvas
                 anchors.fill: parent

--- a/pkdiagram/resources/qml/Personal/LearnView.qml
+++ b/pkdiagram/resources/qml/Personal/LearnView.qml
@@ -21,6 +21,10 @@ Page {
     property bool showClusters: clusterModel ? clusterModel.showClusters : true
     onShowClustersChanged: { timelineZoom = 1.0; timelineScrollX = 0 }
 
+    // Baseline view: show raw SARF lines + dots when clusters are enabled but none detected yet (new diagrams)
+    property bool hasClusters: clusterModel && clusterModel.hasClusters
+    property bool showBaselineView: !hasClusters
+
     // WCAG AA colors for SARF
     readonly property color symptomColor: "#e05555"
     readonly property color anxietyColor: "#40a060"
@@ -811,12 +815,14 @@ Page {
                 color: util.IS_UI_DARK_MODE ? "#151520" : "#f5f5fa"
             }
 
-            // // Baseline
-            // Rectangle {
-            //     x: gLeft; y: yPosMini(0)
-            //     width: gWidth; height: 1
-            //     color: dividerColor
-            // }
+            // Baseline zero-line (shown in baseline view when SARF data exists)
+            Rectangle {
+                visible: showBaselineView && !isFocused && sarfGraphModel && sarfGraphModel.hasData
+                x: gLeft; y: yPosMini(0)
+                width: gWidth; height: 1
+                color: dividerColor
+                opacity: 0.5
+            }
 
             // Graph lines
             Canvas {
@@ -827,8 +833,48 @@ Page {
                 onPaint: {
                     var ctx = getContext("2d")
                     ctx.clearRect(0, 0, width, height)
-                    // Focused mode is handled by focusedViewContainer - nothing to draw here
-                    // Non-focused mode: cluster bars handle visualization
+                    // Focused mode is handled by focusedViewContainer
+                    if (isFocused) return
+                    // Draw SARF cumulative lines in baseline view (no clusters) or raw data mode
+                    if (!showBaselineView && showClusters) return
+                    if (!sarfGraphModel || !sarfGraphModel.cumulative || sarfGraphModel.cumulative.length < 2) return
+
+                    var cumulative = sarfGraphModel.cumulative
+
+                    // Draw baseline (zero) line
+                    ctx.strokeStyle = Qt.rgba(dividerColor.r, dividerColor.g, dividerColor.b, 0.5)
+                    ctx.lineWidth = 1
+                    ctx.beginPath()
+                    ctx.moveTo(gLeft, yPosMini(0))
+                    ctx.lineTo(gRight, yPosMini(0))
+                    ctx.stroke()
+
+                    // Draw SARF lines
+                    var lines = [
+                        {key: "symptom", color: symptomColor},
+                        {key: "anxiety", color: anxietyColor},
+                        {key: "functioning", color: functioningColor}
+                    ]
+                    for (var l = 0; l < lines.length; l++) {
+                        var key = lines[l].key
+                        var hasChange = false
+                        for (var c = 1; c < cumulative.length; c++) {
+                            if (cumulative[c][key] !== cumulative[0][key]) { hasChange = true; break }
+                        }
+                        if (!hasChange) continue
+
+                        ctx.strokeStyle = lines[l].color.toString()
+                        ctx.lineWidth = 2
+                        ctx.beginPath()
+                        var first = true
+                        for (var i = 0; i < cumulative.length; i++) {
+                            var x = xPosZoomed(cumulative[i].yearFrac)
+                            var y = yPosMini(cumulative[i][key])
+                            if (first) { ctx.moveTo(x, y); first = false }
+                            else { ctx.lineTo(x, y) }
+                        }
+                        ctx.stroke()
+                    }
                 }
             }
 
@@ -853,6 +899,9 @@ Page {
             Connections {
                 target: root
                 function onFocusedClusterIndexChanged() { graphCanvas.requestPaint() }
+                function onShowBaselineViewChanged() { graphCanvas.requestPaint() }
+                function onTimelineZoomChanged() { graphCanvas.requestPaint() }
+                function onTimelineScrollXChanged() { graphCanvas.requestPaint() }
             }
 
             // Time markers on x-axis (always visible, adaptive granularity)
@@ -949,7 +998,7 @@ Page {
                 MouseArea {
                     anchors.fill: parent
                     acceptedButtons: Qt.NoButton
-                    enabled: !showClusters
+                    enabled: !showClusters || showBaselineView
                     onWheel: {
                         var deltaX = wheel.angleDelta.x !== 0 ? wheel.angleDelta.x : wheel.angleDelta.y
                         var maxScroll = Math.max(0, gWidth * timelineZoom - gWidth)
@@ -961,7 +1010,7 @@ Page {
                 // Pinch to zoom with drag-to-pan (active when cluster container isn't handling it)
                 PinchArea {
                     anchors.fill: parent
-                    enabled: !showClusters
+                    enabled: !showClusters || showBaselineView
 
                     property real startZoom: 1.0
                     property real startScrollX: 0
@@ -1023,7 +1072,7 @@ Page {
                 width: gWidth
                 height: miniGraphH
                 clip: true
-                visible: showClusters
+                visible: showClusters && !showBaselineView
                 z: 150
 
                 // Wheel scroll for panning
@@ -1263,9 +1312,9 @@ Page {
                 }
             }
 
-            // Event dot markers on graph (only shown in raw data mode - not cluster mode)
+            // Event dot markers on graph (shown in raw data mode or baseline view when no clusters detected)
             Repeater {
-                model: sarfGraphModel && !showClusters ? sarfGraphModel.events : []
+                model: sarfGraphModel && (!showClusters || showBaselineView) ? sarfGraphModel.events : []
                 Item {
                     x: xPosZoomed(modelData.yearFrac) - 20
                     y: yPosMini(0) - 20


### PR DESCRIPTION
## Summary

- In newly created diagrams, the LearnView SARF graph area was blank because `showClusters` defaults to `true` but no clusters exist yet
- Added `showBaselineView` fallback that renders cumulative SARF lines, event dots, and a zero-reference line until clusters are detected by the AI
- Automatically transitions to cluster view once detection completes — no user action needed

## Root Cause

When `showClusters` is `true` (default) but `hasClusters` is `false` (new diagram):
1. Event dots were hidden (only shown when `!showClusters`)
2. Cluster bars container was visible but empty (no clusters to show)
3. `graphCanvas.onPaint` drew nothing
4. Result: completely blank graph area

## Changes

- `LearnView.qml`: Added `showBaselineView` property, SARF line drawing in `graphCanvas`, conditional event dot visibility, baseline zero-line, zoom/pan interaction fixes
- `doc/asbuilts/LEARN_VIEW.md`: Updated as-built documentation

## Test plan

- [ ] Open a new diagram in the Personal app — graph should show SARF lines and event dots
- [ ] Add events and verify they appear on the graph immediately
- [ ] Trigger cluster detection — view should transition from baseline to cluster bars
- [ ] Toggle "Show Clusters" off — raw data mode should still work
- [ ] Verify zoom/pan works in baseline view
- [ ] Verify existing diagrams with clusters still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)