### PR TITLE
FD-319: signal re-extraction cursor on PDP accept

### DIFF
--- a/doc/specs/DATA_SYNC_FLOW.md
+++ b/doc/specs/DATA_SYNC_FLOW.md
@@ -109,6 +109,20 @@ committed items (positive IDs). When a PDP item is accepted,
 `pdp.*` to the top-level `people`/`events`/`pair_bonds` lists, and remaps all
 references.
 
+### Re-extraction cursor signal (FD-319)
+
+Accept commits items locally then saves the blob (above). Separately,
+`_doAcceptPDPItem` / `acceptAllPDPItems` fire a best-effort
+`POST /personal/discussions/<id>/commit-pdp` with `{item_ids, full_accept}`
+(`PersonalAppController._postCommitPdp`). `full_accept` = the staged PDP is
+fully drained after this accept. The server advances the re-extraction cursor
+(`discussions.extracted_through_order`) only on `full_accept`, so the next
+extract treats already-accepted conversation as context-only. Failure is safe:
+the cursor simply doesn't advance and the next extract re-windows, with the
+server-side committed-duplicate guard absorbing any repeat. The cursor never
+advances until this client call ships (legacy behaviour preserved). Concurrency
+hardening of extract/accept is tracked in FD-331.
+
 ## Version Tracking
 
 Each diagram has a `version` integer. The server increments it atomically on

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -1047,6 +1047,9 @@ class PersonalAppController(QObject):
 
         def applyChange(diagramData: DiagramData):
             _log.info(f"Applying accept PDP item change for id: {id}")
+            if not diagramData.pdp:
+                _log.warning("No PDP data available")
+                return diagramData
             if self.scene is not None:
                 diagramData.lastItemId = max(
                     diagramData.lastItemId, self.scene.lastItemId()
@@ -1324,6 +1327,9 @@ class PersonalAppController(QObject):
             drained = {}
 
             def applyChange(diagramData: DiagramData):
+                if not diagramData.pdp:
+                    _log.warning("No PDP data available")
+                    return diagramData
                 if self.scene is not None:
                     diagramData.lastItemId = max(
                         diagramData.lastItemId, self.scene.lastItemId()

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -277,7 +277,9 @@ class PersonalAppController(QObject):
         # — those may contain other-client items Personal's Scene never
         # loaded, which would get interpreted as deletes on the next save.
         # Plan: doc/plans/2026-05-01--mvp-merge-fix/README.md
-        snapshotBytes = getattr(self._diagram, "_lastSavedSnapshot", None) or self._diagram.data
+        snapshotBytes = (
+            getattr(self._diagram, "_lastSavedSnapshot", None) or self._diagram.data
+        )
         openSnapshot = pickle.loads(snapshotBytes) if snapshotBytes else {}
 
         # Capture Scene state NOW (caller-side) so we can stash it as the
@@ -306,7 +308,9 @@ class PersonalAppController(QObject):
                 diagramData.version = sceneDiagramData.version
                 diagramData.versionCompat = sceneDiagramData.versionCompat
                 diagramData.name = sceneDiagramData.name
-                diagramData.lastItemId = max(diagramData.lastItemId, sceneDiagramData.lastItemId)
+                diagramData.lastItemId = max(
+                    diagramData.lastItemId, sceneDiagramData.lastItemId
+                )
                 diagramData.clusters = self.clusterModel.clusters
                 diagramData.clusterCacheKey = self.clusterModel.cacheKey
                 return diagramData
@@ -1014,10 +1018,32 @@ class PersonalAppController(QObject):
 
         return self._withSaveGuard(_do)
 
+    def _postCommitPdp(self, itemIds: list[int], fullAccept: bool):
+        """Tell the backend which staged items were accepted so the
+        re-extraction cursor advances on a full accept. Best-effort: a failure
+        only means the cursor doesn't advance (next extract re-windows; the
+        server-side committed-duplicate guard absorbs the repeat)."""
+        if not self._currentDiscussion or not itemIds:
+            return
+
+        def onError():
+            _log.warning(f"commit-pdp cursor advance failed: {reply.errorString()}")
+
+        reply = self.session.server().nonBlockingRequest(
+            "POST",
+            f"/personal/discussions/{self._currentDiscussion.id}/commit-pdp",
+            data={"item_ids": itemIds, "full_accept": fullAccept},
+            error=onError,
+            success=lambda: None,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            from_root=True,
+        )
+
     def _doAcceptPDPItem(self, id: int) -> bool:
         _log.info(f"Accepting PDP item with id: {id}")
 
         committedItems = {"people": [], "events": [], "pair_bonds": [], "emotions": []}
+        drained = {}
 
         def applyChange(diagramData: DiagramData):
             _log.info(f"Applying accept PDP item change for id: {id}")
@@ -1042,6 +1068,11 @@ class PersonalAppController(QObject):
             committedItems["pair_bonds"] = [
                 pb for pb in diagramData.pair_bonds if pb["id"] not in prevPairBondIds
             ]
+            drained["v"] = not (
+                diagramData.pdp.people
+                or diagramData.pdp.events
+                or diagramData.pdp.pair_bonds
+            )
 
             return diagramData
 
@@ -1055,6 +1086,7 @@ class PersonalAppController(QObject):
         if success:
             self._addCommittedItemsToScene(committedItems)
             self.pdpChanged.emit()
+            self._postCommitPdp([id], drained.get("v", False))
         else:
             _log.warning(f"Failed to accept PDP item after retries")
 
@@ -1289,6 +1321,7 @@ class PersonalAppController(QObject):
                 "pair_bonds": [],
                 "emotions": [],
             }
+            drained = {}
 
             def applyChange(diagramData: DiagramData):
                 if self.scene is not None:
@@ -1312,6 +1345,11 @@ class PersonalAppController(QObject):
                     for pb in diagramData.pair_bonds
                     if pb["id"] not in prevPairBondIds
                 ]
+                drained["v"] = not (
+                    diagramData.pdp.people
+                    or diagramData.pdp.events
+                    or diagramData.pdp.pair_bonds
+                )
 
                 return diagramData
 
@@ -1323,6 +1361,7 @@ class PersonalAppController(QObject):
                 self._addCommittedItemsToScene(committedItems)
                 self.pdpChanged.emit()
                 self.clusterModel.detect()
+                self._postCommitPdp(allIds, drained.get("v", True))
             else:
                 _log.warning("Failed to accept all PDP items after retries")
 

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -354,6 +354,68 @@ def test_acceptAllPDPItems_adds_to_scene(test_user, personalApp: PersonalAppCont
             assert "pair_bonds" in args
 
 
+def test_acceptPDPItem_posts_commit_pdp_partial(
+    test_user, discussion, personalApp: PersonalAppController
+):
+    """Accepting one of several staged items POSTs commit-pdp with that id and
+    full_accept False (cursor must not advance)."""
+    initial = DiagramData(
+        pdp=PDP(people=[Person(id=-1, name="A"), Person(id=-2, name="B")])
+    )
+    personalApp._diagram = Diagram(
+        id=1,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(initial)),
+    )
+    personalApp._currentDiscussion = discussion
+    server = MagicMock()
+    with (
+        patch.object(personalApp, "_addCommittedItemsToScene"),
+        patch.object(personalApp._diagram, "save", return_value=True),
+        patch.object(personalApp.session, "server", return_value=server),
+    ):
+        personalApp._doAcceptPDPItem(-1)
+
+    server.nonBlockingRequest.assert_called_once()
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert args[0] == "POST"
+    assert args[1] == f"/personal/discussions/{discussion.id}/commit-pdp"
+    assert kwargs["data"] == {"item_ids": [-1], "full_accept": False}
+
+
+def test_acceptAllPDPItems_posts_commit_pdp_full(
+    test_user, discussion, personalApp: PersonalAppController
+):
+    """Accept-all POSTs commit-pdp with every id and full_accept True so the
+    re-extraction cursor advances."""
+    initial = DiagramData(
+        pdp=PDP(people=[Person(id=-1, name="A"), Person(id=-2, name="B")])
+    )
+    personalApp._diagram = Diagram(
+        id=1,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(initial)),
+    )
+    personalApp._currentDiscussion = discussion
+    server = MagicMock()
+    with (
+        patch.object(personalApp, "_addCommittedItemsToScene"),
+        patch.object(personalApp._diagram, "save", return_value=True),
+        patch.object(personalApp.session, "server", return_value=server),
+    ):
+        personalApp.acceptAllPDPItems()
+
+    server.nonBlockingRequest.assert_called_once()
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert args[1] == f"/personal/discussions/{discussion.id}/commit-pdp"
+    assert set(kwargs["data"]["item_ids"]) == {-1, -2}
+    assert kwargs["data"]["full_accept"] is True
+
+
 def test_acceptPDPItem_triggers_cluster_detection(
     test_user, personalApp: PersonalAppController
 ):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+testpaths = pkdiagram/tests
 addopts = -vv --ignore=lib --ignore=sysroot --ignore=test_qml.py --disable-warnings -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark  --ignore=familydiagram/sysroot
 junit_family=legacy
 markers =


### PR DESCRIPTION
Personal app now POSTs /personal/discussions/<id>/commit-pdp with the accepted item ids and a full_accept flag (staged pool drained) on both single-item and accept-all. Server advances the re-extraction cursor only on full accept; the call is best-effort (failure just means the next extract re-windows, absorbed by the committed-duplicate guard). Updates DATA_SYNC_FLOW as-built; adds controller tests for partial and full accept. Concurrency hardening tracked in FD-331.