### PR TITLE
FD-332: surface every PDP entry kind in the review sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ These bridge commands make multi-instance tests deterministic without `time.slee
 | Triangle View | [TRIANGLE_VIEW.md](doc/asbuilts/TRIANGLE_VIEW.md) | `scene/triangle.py`, `models/trianglemodel.py`, `TriangleView.qml` |
 | Learn View | [LEARN_VIEW.md](doc/asbuilts/LEARN_VIEW.md) | `resources/qml/Personal/LearnView.qml`, `personal/sarfgraphmodel.py`, `personal/clustermodel.py` |
 | Timeline Click | [TIMELINE_CLICK_IMPLEMENTED.md](doc/asbuilts/TIMELINE_CLICK_IMPLEMENTED.md) | Timeline event selection |
-| Data Sync | [DATA_SYNC_FLOW.md](doc/specs/DATA_SYNC_FLOW.md) | `server_types.py` (`mutate`, `pushToServer`, `save`), `personal/personalappcontroller.py` (`saveDiagram`, `_doAcceptPDPItem`, `_addCommittedItemsToScene`) |
+| Data Sync | [DATA_SYNC_FLOW.md](doc/specs/DATA_SYNC_FLOW.md) | `server_types.py` (`mutate`, `pushToServer`, `save`), `personal/personalappcontroller.py` (`saveDiagram`, `_doAcceptPDPItem`, `_addCommittedItemsToScene`, `dismissEmptyExtraction`, `resolvePairBondChildren`), `resources/qml/Personal/` (`PDPSheet.qml`, `PDPPairBondCard.qml`, `DiscussView.qml` empty-extraction routing) |
 
 As-built docs contain:
 - Component relationships and data flow

--- a/build/osx-config/Info.plist
+++ b/build/osx-config/Info.plist
@@ -52,7 +52,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.23b1</string>
+	<string>2.1.23b2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -73,7 +73,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.1.23b1</string>
+	<string>2.1.23b2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.healthcare-fitness</string>
 	<key>NSHighResolutionCapable</key>

--- a/doc/specs/DATA_SYNC_FLOW.md
+++ b/doc/specs/DATA_SYNC_FLOW.md
@@ -246,6 +246,26 @@ Removes the item and cascade-dependent items from PDP:
 
 Modifies a single field on a PDP item. Used for inline editing in the PDP sheet.
 
+### PDP Review Surface (FD-332)
+
+The review sheet (`PDPSheet.qml`) renders a card for **every** PDP entry kind —
+`people`, `events`, AND `pair_bonds` — with no positive/negative id filter.
+Pair bonds (including those linking already-committed people, e.g. setting a
+person's parents) get `PDPPairBondCard.qml`, styled as an entity card like the
+person card (not an event/SARF pill). `PersonalAppController.resolvePairBondChildren`
+names the person whose `parents` points at the bond ("Parents of"). The badge
+count (`PersonalContainer.qml`) counts all three collections, so a non-empty
+pool can never show "0".
+
+An extraction that yields nothing does NOT open an empty deck: `onExtractCompleted`
+shows the "Nothing New" info dialog and calls
+`PersonalAppController.dismissEmptyExtraction()`, which advances the
+re-extraction cursor via `_postCommitPdp([], True)` (same bookkeeping as a full
+accept of an empty pool) so the Extract button clears.
+
+Out of scope (deferred): edits to already-committed people/events and deletes
+of committed entities are not carried in the pool today and have no card.
+
 ### Clear Diagram Data
 
 Wipes events, PDP, and optionally people/pair_bonds/emotions. Dev/test reset.

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -1299,6 +1299,26 @@ class PersonalAppController(QObject):
                 return nameA or nameB
         return ""
 
+    @pyqtSlot(int, result=str)
+    @pyqtSlot("QVariant", result=str)
+    def resolvePairBondChildren(self, pairBondId: int | None) -> str:
+        """Names of people whose parents point at this pair bond — surfaces
+        the structural change a pair-bond card applies (e.g. setting an
+        already-committed person's parents)."""
+        if pairBondId is None or not self._diagram:
+            return ""
+        names = []
+        diagramData = self._diagram.getDiagramData()
+        if diagramData.pdp:
+            for p in diagramData.pdp.people:
+                if p.parents == pairBondId:
+                    names.append(p.name or p.last_name or f"Person #{p.id}")
+        if self.scene:
+            for person in self.scene.people():
+                if person.parents() and person.parents().id == pairBondId:
+                    names.append(person.fullNameOrAlias())
+        return ", ".join(n for n in names if n)
+
     @pyqtSlot(str, result=str)
     @pyqtSlot("QVariant", result=str)
     def eventKindLabel(self, kind: str | None) -> str:
@@ -1436,6 +1456,13 @@ class PersonalAppController(QObject):
                 _log.warning("Failed to accept all PDP items after retries")
 
         self._withSaveGuard(_do)
+
+    @pyqtSlot()
+    def dismissEmptyExtraction(self):
+        """An extraction produced nothing to review. Nothing is committed, but
+        the conversation must still be marked covered so the Extract button
+        clears — same cursor advance as a full accept of an empty pool."""
+        self._postCommitPdp([], True)
 
     @pyqtSlot(int, str, "QVariant")
     def updatePDPItem(self, id: int, field: str, value):

--- a/pkdiagram/resources/qml/Personal/DiscussView.qml
+++ b/pkdiagram/resources/qml/Personal/DiscussView.qml
@@ -146,7 +146,14 @@ Page {
         }
         function onExtractCompleted(summary) {
             extractOverlay.visible = false
-            pdpSheet.open()
+            var total = (summary.people || 0) + (summary.events || 0) + (summary.pairBonds || 0)
+            if (total > 0) {
+                pdpSheet.open()
+            } else {
+                personalApp.dismissEmptyExtraction()
+                util.informationBox("Nothing New",
+                    "Nothing new was detected. Chat more to generate more data.")
+            }
         }
         function onExtractFailed(error) {
             extractOverlay.visible = false

--- a/pkdiagram/resources/qml/Personal/PDPPairBondCard.qml
+++ b/pkdiagram/resources/qml/Personal/PDPPairBondCard.qml
@@ -1,0 +1,191 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import "../PK" 1.0 as PK
+
+Rectangle {
+    id: root
+
+    anchors.fill: parent
+
+    property var pairBondData
+    property var pdp
+
+    signal accepted(int id)
+    signal rejected(int id)
+    signal horizontalWheel(real deltaX)
+
+    color: util.QML_ITEM_BG
+    radius: 12
+    border.color: util.QML_ITEM_BORDER_COLOR
+    border.width: 1
+
+    readonly property string personAName: personalApp && pairBondData ? personalApp.resolvePersonName(pairBondData.person_a) : ""
+    readonly property string personBName: personalApp && pairBondData ? personalApp.resolvePersonName(pairBondData.person_b) : ""
+    readonly property string childNames: personalApp && pairBondData ? personalApp.resolvePairBondChildren(pairBondData.id) : ""
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 12
+        spacing: 8
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            Rectangle {
+                Layout.preferredWidth: 28
+                Layout.preferredHeight: 28
+                radius: 14
+                color: util.QML_HIGHLIGHT_COLOR
+                opacity: 0.2
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "⚭"
+                    font.pixelSize: 16
+                    color: util.QML_TEXT_COLOR
+                }
+            }
+
+            Text {
+                text: "Pair Bond"
+                font.pixelSize: util.QML_SMALL_TITLE_FONT_SIZE
+                font.family: util.FONT_FAMILY_TITLE
+                color: util.QML_TEXT_COLOR
+                Layout.fillWidth: true
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: util.QML_ITEM_BORDER_COLOR
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            MouseArea {
+                anchors.fill: parent
+                z: 1
+                acceptedButtons: Qt.NoButton
+                onWheel: function(event) {
+                    if (Math.abs(event.angleDelta.y) > Math.abs(event.angleDelta.x)) {
+                        flickable.contentY = Math.max(0,
+                            Math.min(flickable.contentHeight - flickable.height,
+                                flickable.contentY - event.angleDelta.y))
+                    } else {
+                        root.horizontalWheel(event.angleDelta.x)
+                    }
+                    event.accepted = true
+                }
+            }
+
+            Flickable {
+                id: flickable
+                anchors.fill: parent
+                contentHeight: fieldsColumn.height
+                clip: true
+                flickableDirection: Flickable.VerticalFlick
+                boundsBehavior: Flickable.StopAtBounds
+
+                ScrollBar.vertical: ScrollBar {
+                    policy: ScrollBar.AlwaysOn
+                    visible: flickable.contentHeight > flickable.height
+                }
+
+                ColumnLayout {
+                    id: fieldsColumn
+                    width: flickable.width - 12
+                    spacing: 6
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+                        visible: root.personAName !== "" || root.personBName !== ""
+
+                        Text {
+                            text: "Partners"
+                            font.pixelSize: 10
+                            font.bold: true
+                            color: util.QML_TEXT_COLOR
+                            opacity: 0.7
+                        }
+                        Text {
+                            text: {
+                                if (root.personAName && root.personBName)
+                                    return root.personAName + " & " + root.personBName
+                                return root.personAName || root.personBName
+                            }
+                            font.pixelSize: util.TEXT_FONT_SIZE
+                            color: util.QML_TEXT_COLOR
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+                        visible: root.childNames !== ""
+
+                        Text {
+                            text: "Parents of"
+                            font.pixelSize: 10
+                            font.bold: true
+                            color: util.QML_TEXT_COLOR
+                            opacity: 0.7
+                        }
+                        Text {
+                            text: root.childNames
+                            font.pixelSize: util.TEXT_FONT_SIZE
+                            color: util.QML_TEXT_COLOR
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: util.QML_ITEM_BORDER_COLOR
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 36
+            spacing: 8
+
+            PK.Button {
+                id: rejectButton
+                objectName: "pdpRejectButton"
+                source: '../../clear-button.png'
+                Layout.preferredWidth: 36
+                Layout.preferredHeight: 36
+                onClicked: {
+                    if (pairBondData)
+                        root.rejected(pairBondData.id)
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            PK.Button {
+                id: acceptButton
+                objectName: "pdpAcceptButton"
+                source: '../../plus-button.png'
+                Layout.preferredWidth: 36
+                Layout.preferredHeight: 36
+                onClicked: {
+                    if (pairBondData)
+                        root.accepted(pairBondData.id)
+                }
+            }
+        }
+    }
+}

--- a/pkdiagram/resources/qml/Personal/PDPSheet.qml
+++ b/pkdiagram/resources/qml/Personal/PDPSheet.qml
@@ -58,25 +58,32 @@ Drawer {
             return
         }
 
-        // Only show negative-ID items (PDP proposals); positive IDs are committed item updates
-        if (pdp.events) {
-            for (var i = 0; i < pdp.events.length; i++) {
-                if (pdp.events[i].id < 0) {
-                    itemsModel.append({
-                        "itemType": "event",
-                        "itemId": pdp.events[i].id
-                    })
-                }
-            }
-        }
+        // Every entry in the PDP is a pending change to review — new people,
+        // new events, and pair bonds (which may link already-committed people,
+        // e.g. setting someone's parents). Render a card for each so the view
+        // is never empty when the PDP has content.
         if (pdp.people) {
             for (var i = 0; i < pdp.people.length; i++) {
-                if (pdp.people[i].id < 0) {
-                    itemsModel.append({
-                        "itemType": "person",
-                        "itemId": pdp.people[i].id
-                    })
-                }
+                itemsModel.append({
+                    "itemType": "person",
+                    "itemId": pdp.people[i].id
+                })
+            }
+        }
+        if (pdp.pair_bonds) {
+            for (var i = 0; i < pdp.pair_bonds.length; i++) {
+                itemsModel.append({
+                    "itemType": "pair_bond",
+                    "itemId": pdp.pair_bonds[i].id
+                })
+            }
+        }
+        if (pdp.events) {
+            for (var i = 0; i < pdp.events.length; i++) {
+                itemsModel.append({
+                    "itemType": "event",
+                    "itemId": pdp.events[i].id
+                })
             }
         }
         itemCount = itemsModel.count
@@ -96,6 +103,10 @@ Drawer {
 
     function findEventById(id) {
         return findItemById(pdp ? pdp.events : null, id)
+    }
+
+    function findPairBondById(id) {
+        return findItemById(pdp ? pdp.pair_bonds : null, id)
     }
 
     function removeItemById(id) {
@@ -305,6 +316,7 @@ Drawer {
                 objectName: "acceptAllButton"
                 text: "Accept All"
                 pill: true
+                visible: root.itemCount > 0
                 onClicked: root.acceptAllClicked()
             }
         }
@@ -315,6 +327,22 @@ Drawer {
             color: util.QML_ITEM_BORDER_COLOR
         }
 
+        Item {
+            objectName: "pdpEmptyState"
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            visible: root.itemCount === 0
+
+            Text {
+                anchors.centerIn: parent
+                text: "No changes detected"
+                font.pixelSize: util.QML_TITLE_FONT_SIZE
+                font.family: util.FONT_FAMILY_TITLE
+                color: util.QML_INACTIVE_TEXT_COLOR
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+
         SwipeView {
             id: cardStack
             objectName: "pdpCardStack"
@@ -323,6 +351,7 @@ Drawer {
             Layout.margins: util.QML_MARGINS
             clip: true
             interactive: true
+            visible: root.itemCount > 0
 
             Repeater {
                 id: cardRepeater
@@ -344,6 +373,8 @@ Drawer {
                                 return personCardComponent
                             } else if (model.itemType === "event") {
                                 return eventCardComponent
+                            } else if (model.itemType === "pair_bond") {
+                                return pairBondCardComponent
                             }
                             return null
                         }
@@ -354,6 +385,9 @@ Drawer {
                                 item.pdp = root.pdp
                             } else if (model.itemType === "event") {
                                 item.eventData = root.findEventById(model.itemId)
+                                item.pdp = root.pdp
+                            } else if (model.itemType === "pair_bond") {
+                                item.pairBondData = root.findPairBondById(model.itemId)
                                 item.pdp = root.pdp
                             }
                         }
@@ -366,6 +400,7 @@ Drawer {
             id: pageIndicator
             Layout.alignment: Qt.AlignHCenter
             Layout.bottomMargin: util.QML_MARGINS
+            visible: root.itemCount > 0
             count: itemsModel.count
             currentIndex: cardStack.currentIndex
             interactive: false
@@ -983,6 +1018,16 @@ Drawer {
             onEditRequested: function(eventData) {
                 root.openEventEditOverlay(eventData)
             }
+            onHorizontalWheel: root.handleHorizontalWheel(deltaX)
+        }
+    }
+
+    Component {
+        id: pairBondCardComponent
+
+        Personal.PDPPairBondCard {
+            onAccepted: root.handleAccept(id)
+            onRejected: root.handleReject(id)
             onHorizontalWheel: root.handleHorizontalWheel(deltaX)
         }
     }

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -52,15 +52,13 @@ Page {
         function onPdpChanged() {
             var pdp = personalApp.pdp
             if (pdp) {
+                // Every PDP entry is a reviewable pending change; the badge
+                // must match the card count in PDPSheet (people + pair bonds
+                // + events), or a non-empty PDP can show a "0" badge.
                 var count = 0
-                function countNegativeIds(items) {
-                    var n = 0
-                    for (var i = 0; i < items.length; i++)
-                        if (items[i].id < 0) n++
-                    return n
-                }
-                if (pdp.events) count += countNegativeIds(pdp.events)
-                if (pdp.people) count += countNegativeIds(pdp.people)
+                if (pdp.people) count += pdp.people.length
+                if (pdp.pair_bonds) count += pdp.pair_bonds.length
+                if (pdp.events) count += pdp.events.length
                 root.pdpCount = count
             } else {
                 root.pdpCount = 0

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -21,7 +21,7 @@ from PyQt5.QtCore import QByteArray
 from PyQt5.QtWidgets import QMessageBox
 
 from btcopilot.extensions import db
-from btcopilot.schema import DiagramData, PDP, Person, asdict
+from btcopilot.schema import DiagramData, PDP, Person, PairBond, asdict
 
 pytestmark = [
     pytest.mark.component("Personal"),
@@ -152,6 +152,38 @@ def test_rejectPDPItem_undo(test_user, personalApp: PersonalAppController):
         personalApp._undoStack.redo()
         assert reject.call_count == 2
         assert not personalApp._undoStack.canRedo()
+
+
+def test_pdp_surfaces_pair_bonds_and_parents_link(
+    test_user, personalApp: PersonalAppController
+):
+    """FD-332: a pair bond (e.g. setting someone's parents) must be reviewable
+    in the PDP, not silently invisible. The pdp property exposes pair_bonds and
+    resolvePairBondChildren names the person whose parents it sets so the card
+    can emphasize the change."""
+    diagram_data = DiagramData(
+        pdp=PDP(
+            people=[
+                Person(id=-1, name="Wally"),
+                Person(id=-2, name="Louann"),
+                Person(id=-3, name="Robert", parents=-10),
+            ],
+            pair_bonds=[PairBond(id=-10, person_a=-1, person_b=-2)],
+        )
+    )
+    personalApp._diagram = Diagram(
+        id=1,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(diagram_data)),
+    )
+
+    pdp = personalApp.pdp
+    assert [pb["id"] for pb in pdp["pair_bonds"]] == [-10]
+    assert personalApp.resolvePersonName(-1) == "Wally"
+    assert personalApp.resolvePairBondChildren(-10) == "Robert"
+    assert personalApp.resolvePairBondChildren(None) == ""
 
 
 def test_undo_stack_multiple_operations(test_user, personalApp: PersonalAppController):
@@ -352,6 +384,39 @@ def test_acceptAllPDPItems_adds_to_scene(test_user, personalApp: PersonalAppCont
             assert "people" in args
             assert "events" in args
             assert "pair_bonds" in args
+
+
+def test_dismissEmptyExtraction_advances_cursor(
+    test_user, discussion, personalApp: PersonalAppController
+):
+    """An empty extraction shows an info dialog (not a deck); dismissing it must
+    still mark the conversation covered — POST commit-pdp with empty item_ids and
+    full_accept True, same cursor advance as a full accept."""
+    personalApp._currentDiscussion = discussion
+    server = MagicMock()
+    with patch.object(personalApp.session, "server", return_value=server):
+        personalApp.dismissEmptyExtraction()
+
+    server.nonBlockingRequest.assert_called_once()
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert args[0] == "POST"
+    assert args[1] == f"/personal/discussions/{discussion.id}/commit-pdp"
+    assert kwargs["data"]["item_ids"] == []
+    assert kwargs["data"]["full_accept"] is True
+
+
+def test_dismissEmptyExtraction_no_discussion_is_noop(
+    test_user, personalApp: PersonalAppController
+):
+    """No current discussion -> _postCommitPdp guard returns before building
+    the f-string path off _currentDiscussion.id (would AttributeError on None).
+    Must not raise and must not POST."""
+    personalApp._currentDiscussion = None
+    server = MagicMock()
+    with patch.object(personalApp.session, "server", return_value=server):
+        personalApp.dismissEmptyExtraction()
+
+    server.nonBlockingRequest.assert_not_called()
 
 
 def test_acceptPDPItem_posts_commit_pdp_partial(


### PR DESCRIPTION
## Why

The Personal PDP review sheet only rendered cards for new (negative-id)
people and events. Pair bonds — how "X and Y are Z's parents" is
represented — got no card at all, and non-new entries were filtered out.
Result: telling the coach "X and Y are Z's parents" produced an empty
review deck with a lone Accept button, so users accepted changes they
could not see. (FD-332)

## What changed (frontend only)

- **New `PDPPairBondCard.qml`** — entity-styled card (icon + "Pair Bond"
  + Partners + "Parents of"), matching the person card, not an
  event/SARF pill.
- **`PDPSheet.qml`** renders people, events *and* pair bonds with no
  positive/negative id filter — every pool entry is reviewable.
- **`PersonalContainer.qml`** badge counts all pool entries, so a
  non-empty pool can never show "0".
- **`DiscussView.qml`** — an extraction that finds nothing no longer
  opens an empty deck: it shows a "Nothing New" info dialog and calls
  `dismissEmptyExtraction()`, which advances the re-extraction cursor so
  the Extract button clears (same bookkeeping the old empty "Accept All"
  did).
- **`personalappcontroller.py`** — `resolvePairBondChildren()` (read-only,
  drives "Parents of") and `dismissEmptyExtraction()`.
- Tests: pair-bond surface, `dismissEmptyExtraction` cursor advance, and
  its no-current-discussion guard. Docs synced (DATA_SYNC_FLOW.md +
  CLAUDE.md as-built row).

## Out of scope (deferred → FD-333)

Edits to already-committed people/events and deletes of committed
entities. These are not carried in the pending pool today and require
backend work (`apply_deltas` + pool data model + commit/undo). Rare in
practice; split out deliberately. FD-332's acceptance criteria were
amended to the narrowed scope.

## Verification

- All related PDP controller tests green; new tests pass.
- UI-verified by Patrick in the live Personal app against an ephemeral
  backend (worktree branch): pair-bond card renders with Partners /
  Parents of; empty pool no longer shows a deck.
- The "Nothing New" dialog itself is a native OS dialog — trusted on
  unit coverage, not separately screenshot-verified.

## Risk

Low. No backend or commit-path changes; QML rendering + one read-only
slot + one cursor-advance slot reusing the existing empty-accept path.

Closes FD-332. Follow-up: FD-333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
