### PR TITLE
FD-314/315/317: PDP dismiss gesture, time field hidden by default, cluster title truncation

### DIFF
--- a/_pkdiagram/_pkdiagram_mac.mm
+++ b/_pkdiagram/_pkdiagram_mac.mm
@@ -38,10 +38,12 @@ __attribute__((constructor)) static void setRenderLoopForIOS() {
     setenv("QSG_RENDER_LOOP", "basic", 0);
 }
 
-// AVSpeechSynthesizer requires an active audio session with playback category
+// AVSpeechSynthesizer requires playback category; MixWithOthers prevents interrupting background audio
 __attribute__((constructor)) static void setupAudioSessionForIOS() {
     AVAudioSession *session = [AVAudioSession sharedInstance];
-    [session setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [session setCategory:AVAudioSessionCategoryPlayback
+             withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                   error:nil];
     [session setActive:YES error:nil];
 }
 #endif

--- a/build/osx-config/Info.plist
+++ b/build/osx-config/Info.plist
@@ -52,7 +52,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.23b1</string>
+	<string>2.1.23b2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -73,7 +73,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.1.23b1</string>
+	<string>2.1.23b2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.healthcare-fitness</string>
 	<key>NSHighResolutionCapable</key>

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -78,6 +78,7 @@ class PersonalAppController(QObject):
     ttsPlayingIndexChanged = pyqtSignal()
     ttsFinished = pyqtSignal()
     ttsVoiceChanged = pyqtSignal()
+    autoReadAloudChanged = pyqtSignal()
     responseModelChanged = pyqtSignal()
 
     transcriptionReady = pyqtSignal(str, arguments=["text"])
@@ -126,15 +127,22 @@ class PersonalAppController(QObject):
         self._saving = False
         self._saveQueue = []
         self._settings = Settings(self.app.prefs(), self)
-        self._tts = QTextToSpeech(self)
+        self._tts = None
         self._ttsPlayingIndex = -1
-        self._tts.stateChanged.connect(self._onTtsStateChanged)
-        self._initTtsVoice()
+        if self._settings.value("autoReadAloud", False):
+            self._ensureTts()
 
         # Voice recording
         self._audioRecorder = QAudioRecorder(self)
         self._recordingFilePath = ""
         self._networkManager = QNetworkAccessManager(self)
+
+    def _ensureTts(self):
+        if self._tts is not None:
+            return
+        self._tts = QTextToSpeech(self)
+        self._tts.stateChanged.connect(self._onTtsStateChanged)
+        self._initTtsVoice()
 
     def _initTtsVoice(self):
         saved = self._settings.value("ttsVoiceName")
@@ -163,6 +171,8 @@ class PersonalAppController(QObject):
         return None, None
 
     def _collectVoices(self):
+        if self._tts is None:
+            return []
         origLocale = self._tts.locale()
         origVoice = self._tts.voice()
         voices = []
@@ -437,8 +447,20 @@ class PersonalAppController(QObject):
     def ttsPlayingIndex(self):
         return self._ttsPlayingIndex
 
+    @pyqtProperty(bool, notify=autoReadAloudChanged)
+    def autoReadAloud(self):
+        return bool(self._settings.value("autoReadAloud", False))
+
+    @pyqtSlot(bool)
+    def setAutoReadAloud(self, enabled):
+        self._settings.setValue("autoReadAloud", enabled)
+        if enabled:
+            self._ensureTts()
+        self.autoReadAloudChanged.emit()
+
     @pyqtSlot(str, int)
     def sayAtIndex(self, text, index):
+        self._ensureTts()
         self._tts.stop()
         self._ttsPlayingIndex = index
         self.ttsPlayingIndexChanged.emit()
@@ -446,7 +468,8 @@ class PersonalAppController(QObject):
 
     @pyqtSlot()
     def stopSpeaking(self):
-        self._tts.stop()
+        if self._tts is not None:
+            self._tts.stop()
 
     @pyqtProperty("QVariantList", constant=True)
     def ttsVoices(self):
@@ -454,10 +477,13 @@ class PersonalAppController(QObject):
 
     @pyqtProperty(str, notify=ttsVoiceChanged)
     def ttsVoiceName(self):
+        if self._tts is None:
+            return ""
         return self._tts.voice().name()
 
     @pyqtSlot(str)
     def setTtsVoice(self, name):
+        self._ensureTts()
         voice, locale = self._findVoice(name)
         if voice:
             self._tts.setLocale(locale)
@@ -468,6 +494,7 @@ class PersonalAppController(QObject):
 
     @pyqtSlot(str)
     def previewVoice(self, name):
+        self._ensureTts()
         self.setTtsVoice(name)
         self._tts.say("Hello, this is a preview of my voice.")
 

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -132,8 +132,8 @@ class PersonalAppController(QObject):
         if self._settings.value("autoReadAloud", False):
             self._ensureTts()
 
-        # Voice recording
-        self._audioRecorder = QAudioRecorder(self)
+        # Voice recording — lazy init to avoid activating AVAudioSession at startup
+        self._audioRecorder = None
         self._recordingFilePath = ""
         self._networkManager = QNetworkAccessManager(self)
 
@@ -514,9 +514,14 @@ class PersonalAppController(QObject):
 
     # Voice Recording & Transcription
 
+    def _ensureAudioRecorder(self):
+        if self._audioRecorder is None:
+            self._audioRecorder = QAudioRecorder(self)
+
     @pyqtSlot()
     def startRecording(self):
         """Start recording audio via QAudioRecorder."""
+        self._ensureAudioRecorder()
         try:
             tmpFile = tempfile.NamedTemporaryFile(
                 suffix=".wav", delete=False, prefix="fd_voice_"
@@ -542,6 +547,8 @@ class PersonalAppController(QObject):
     @pyqtSlot()
     def cancelRecording(self):
         """Stop recording WITHOUT transcribing (e.g. short tap or drag-off)."""
+        if self._audioRecorder is None:
+            return
         self._audioRecorder.stop()
         _log.info(f"Cancelled recording: {self._recordingFilePath}")
         self._cleanupRecording(self._recordingFilePath)
@@ -550,6 +557,9 @@ class PersonalAppController(QObject):
     @pyqtSlot()
     def stopRecording(self):
         """Stop recording and begin transcription."""
+        if self._audioRecorder is None:
+            self.transcriptionFailed.emit("Recording file not found")
+            return
         self._audioRecorder.stop()
         _log.info(f"Stopped recording: {self._recordingFilePath}")
 
@@ -1049,8 +1059,10 @@ class PersonalAppController(QObject):
 
     @pyqtSlot(int, result=bool)
     def acceptPDPItem(self, id: int, undo=True):
-        if id >= 0:
-            _log.error(f"acceptPDPItem called with non-PDP id {id}, ignoring")
+        if id > 0:
+            return self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True, undo=undo))
+        if id == 0:
+            _log.error(f"acceptPDPItem called with id 0, ignoring")
             return False
 
         def _do():
@@ -1067,8 +1079,10 @@ class PersonalAppController(QObject):
 
     @pyqtSlot(int, result=bool)
     def rejectPDPItem(self, id: int, undo=True):
-        if id >= 0:
-            _log.error(f"rejectPDPItem called with non-PDP id {id}, ignoring")
+        if id > 0:
+            return self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False, undo=undo))
+        if id == 0:
+            _log.error(f"rejectPDPItem called with id 0, ignoring")
             return False
 
         def _do():

--- a/pkdiagram/resources/qml/EventForm.qml
+++ b/pkdiagram/resources/qml/EventForm.qml
@@ -149,6 +149,7 @@ Page {
     readonly property var fieldWidth: 231
 
     property var dirty: false
+    property bool showTime: false
 
     // TODO: Re-add migration logic
 
@@ -193,7 +194,8 @@ Page {
         addPage.scrollToTop()
         tagsEditItem.clear()
         kindBox.forceActiveFocus()
-        root.dirty = false;
+        root.dirty = false
+        root.showTime = false
     }
 
     function currentTab() { return 0 }
@@ -874,6 +876,7 @@ Page {
                         id: startDateButtons
                         datePicker: startDatePicker
                         timePicker: startTimePicker
+                        hideTime: !root.showTime
                         // dateTime: root.startDateTime
                         backTabItem: descriptionField.backTabItem
                         tabItem: endDateButtons.firstTabItem
@@ -920,6 +923,16 @@ Page {
                             target: root
                             function onStartDateTimeChanged() { if(startTimePicker.dateTime != root.startDateTime) startTimePicker.dateTime = root.startDateTime }
                         }                               
+                    }
+
+                    PK.Text {
+                        visible: !root.showTime && Global.isValidDateTime(root.startDateTime)
+                    }
+
+                    PK.Button {
+                        text: "Add time"
+                        visible: !root.showTime && Global.isValidDateTime(root.startDateTime)
+                        onClicked: root.showTime = true
                     }
 
                     PK.Text {

--- a/pkdiagram/resources/qml/Personal/DiscussView.qml
+++ b/pkdiagram/resources/qml/Personal/DiscussView.qml
@@ -96,12 +96,12 @@ Page {
                 "speakerType": 'expert'
             })
             statementsList.delayedScrollToBottom()
-            if (personalApp.settings.value("autoReadAloud", false)) {
+            if (personalApp.autoReadAloud) {
                 personalApp.sayAtIndex(text, chatModel.count - 1)
             }
         }
         function onTtsFinished() {
-            if (personalApp.settings.value("autoReadAloud", false)) {
+            if (personalApp.autoReadAloud) {
                 textEdit.forceActiveFocus()
             }
         }
@@ -380,6 +380,7 @@ Page {
                         width: 28
                         height: 28
                         color: "transparent"
+                        visible: personalApp ? personalApp.autoReadAloud : false
 
                         Canvas {
                             anchors.centerIn: parent

--- a/pkdiagram/resources/qml/Personal/LearnView.qml
+++ b/pkdiagram/resources/qml/Personal/LearnView.qml
@@ -1353,17 +1353,21 @@ Page {
                     }
 
                     Text {
-                        x: 14
+                        id: heroTitleText
+                        anchors.left: parent.left
+                        anchors.leftMargin: 14
+                        anchors.right: heroEventCount.left
+                        anchors.rightMargin: 8
                         anchors.verticalCenter: parent.verticalCenter
                         text: focusedCluster ? focusedCluster.title : ""
                         font.pixelSize: 14
                         font.bold: true
                         color: "white"
                         elide: Text.ElideRight
-                        width: parent.width - 110
                     }
 
                     Text {
+                        id: heroEventCount
                         anchors.right: heroCloseButton.left
                         anchors.rightMargin: 8
                         anchors.verticalCenter: parent.verticalCenter
@@ -1870,18 +1874,22 @@ Page {
                 z: 100
 
                 // Navigation arrows for cycling clusters (shown when focused)
-                Row {
+                RowLayout {
                     visible: isFocused
-                    anchors.centerIn: parent
-                    spacing: 16
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.leftMargin: 8
+                    anchors.rightMargin: 8
+                    anchors.verticalCenter: parent.verticalCenter
                     height: parent.height
+                    spacing: 16
 
                 // Prev button
                 Rectangle {
                     objectName: "clusterPrevButton"
                     width: 40; height: 40; radius: 20
                     color: util.IS_UI_DARK_MODE ? "#333340" : "#e0e0e8"
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.alignment: Qt.AlignVCenter
 
                     Text {
                         anchors.centerIn: parent
@@ -1892,34 +1900,34 @@ Page {
 
                     MouseArea {
                         anchors.fill: parent
-                        anchors.margins: -2  // Extend tap area to 44pt
+                        anchors.margins: -2
                         cursorShape: Qt.PointingHandCursor
                         onClicked: focusPrevCluster()
                     }
                 }
 
-                // Current cluster title and count (fixed width to prevent button movement)
+                // Current cluster title and count
                 Column {
-                    width: 160
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
                     spacing: 3
 
                     Text {
-                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width
                         text: focusedCluster ? focusedCluster.title : ""
                         font.pixelSize: 14
                         font.bold: true
                         color: focusedCluster ? clusterColor(focusedCluster.id) : textPrimary
                         elide: Text.ElideRight
-                        width: parent.width
                         horizontalAlignment: Text.AlignHCenter
                     }
 
                     Text {
-                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width
                         text: (focusedClusterIndex + 1) + " / " + (clusterModel ? clusterModel.count : 0)
                         font.pixelSize: 13
                         color: textSecondary
+                        horizontalAlignment: Text.AlignHCenter
                     }
                 }
 
@@ -1928,7 +1936,7 @@ Page {
                     objectName: "clusterNextButton"
                     width: 40; height: 40; radius: 20
                     color: util.IS_UI_DARK_MODE ? "#333340" : "#e0e0e8"
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.alignment: Qt.AlignVCenter
 
                     Text {
                         anchors.centerIn: parent
@@ -1939,7 +1947,7 @@ Page {
 
                     MouseArea {
                         anchors.fill: parent
-                        anchors.margins: -2  // Extend tap area to 44pt
+                        anchors.margins: -2
                         cursorShape: Qt.PointingHandCursor
                         onClicked: focusNextCluster()
                     }

--- a/pkdiagram/resources/qml/Personal/PDPSheet.qml
+++ b/pkdiagram/resources/qml/Personal/PDPSheet.qml
@@ -273,6 +273,14 @@ Drawer {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
         anchors.topMargin: 8
+
+        MouseArea {
+            anchors.centerIn: parent
+            width: 80
+            height: 32
+            onClicked: root.close()
+            cursorShape: Qt.PointingHandCursor
+        }
     }
 
     ColumnLayout {
@@ -306,6 +314,12 @@ Drawer {
                 text: "Accept All"
                 pill: true
                 onClicked: root.acceptAllClicked()
+            }
+
+            PK.Button {
+                objectName: "dismissButton"
+                text: "✕"
+                onClicked: root.close()
             }
         }
 

--- a/pkdiagram/resources/qml/Personal/VoiceSettingsPage.qml
+++ b/pkdiagram/resources/qml/Personal/VoiceSettingsPage.qml
@@ -114,8 +114,8 @@ Page {
                     anchors.right: parent.right
                     anchors.rightMargin: 6
                     anchors.verticalCenter: parent.verticalCenter
-                    checked: personalApp && personalApp.settings ? personalApp.settings.value("autoReadAloud", false) === true : false
-                    onToggled: if (personalApp && personalApp.settings) personalApp.settings.setValue("autoReadAloud", checked)
+                    checked: personalApp ? personalApp.autoReadAloud : false
+                    onToggled: if (personalApp) personalApp.setAutoReadAloud(checked)
 
                     indicator: Rectangle {
                         implicitWidth: 51

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -582,6 +582,7 @@ def test_startRecording_creates_temp_file_and_records(
     personalApp: PersonalAppController,
 ):
     """startRecording creates a temp WAV file and calls recorder.record()."""
+    personalApp._ensureAudioRecorder()
     with (
         patch.object(personalApp._audioRecorder, "setEncodingSettings"),
         patch.object(personalApp._audioRecorder, "setOutputLocation"),
@@ -625,6 +626,7 @@ def test_stopRecording_stops_recorder_and_transcribes(
     personalApp: PersonalAppController,
 ):
     """stopRecording stops the recorder and begins transcription."""
+    personalApp._ensureAudioRecorder()
     # Create a real temp file so the path exists check passes
     import tempfile as _tempfile
 
@@ -653,6 +655,7 @@ def test_stopRecording_emits_failed_when_no_file(
     personalApp: PersonalAppController,
 ):
     """stopRecording emits transcriptionFailed if recording file is missing."""
+    personalApp._ensureAudioRecorder()
     from pkdiagram.pyqt import QMessageBox
 
     failed = util.Condition(personalApp.transcriptionFailed)
@@ -673,6 +676,7 @@ def test_stopRecording_emits_failed_when_empty_path(
     personalApp: PersonalAppController,
 ):
     """stopRecording emits transcriptionFailed if _recordingFilePath is empty."""
+    personalApp._ensureAudioRecorder()
     from pkdiagram.pyqt import QMessageBox
 
     failed = util.Condition(personalApp.transcriptionFailed)
@@ -692,6 +696,7 @@ def test_cancelRecording_stops_and_cleans_up(
     personalApp: PersonalAppController,
 ):
     """cancelRecording stops the recorder, cleans up temp file, resets path."""
+    personalApp._ensureAudioRecorder()
     import tempfile as _tempfile
 
     tmpFile = _tempfile.NamedTemporaryFile(
@@ -712,6 +717,7 @@ def test_cancelRecording_does_not_transcribe(
     personalApp: PersonalAppController,
 ):
     """cancelRecording should NOT trigger transcription."""
+    personalApp._ensureAudioRecorder()
     import tempfile as _tempfile
 
     tmpFile = _tempfile.NamedTemporaryFile(
@@ -737,6 +743,7 @@ def test_voice_state_idle_to_recording_to_transcribing_to_idle(
     personalApp: PersonalAppController,
 ):
     """Full voice state machine: idle → startRecording → stopRecording → transcriptionReady → idle."""
+    personalApp._ensureAudioRecorder()
     import tempfile as _tempfile
 
     # Start in idle state
@@ -774,6 +781,7 @@ def test_short_tap_cancel_does_not_transcribe(
     personalApp: PersonalAppController,
 ):
     """Simulates short tap behavior: startRecording then immediate cancelRecording (no transcription)."""
+    personalApp._ensureAudioRecorder()
     import tempfile as _tempfile
 
     with (

--- a/pkdiagram/tests/personal/test_tts.py
+++ b/pkdiagram/tests/personal/test_tts.py
@@ -13,6 +13,7 @@ pytestmark = [
 
 
 def test_sayAtIndex_sets_index_and_calls_say(personalApp: PersonalAppController):
+    personalApp._ensureTts()
     changed = util.Condition(personalApp.ttsPlayingIndexChanged)
     with (
         patch.object(personalApp._tts, "say") as say,
@@ -25,6 +26,7 @@ def test_sayAtIndex_sets_index_and_calls_say(personalApp: PersonalAppController)
 
 
 def test_stopSpeaking_calls_stop(personalApp: PersonalAppController):
+    personalApp._ensureTts()
     with patch.object(personalApp._tts, "stop") as stop:
         personalApp.stopSpeaking()
     stop.assert_called_once()
@@ -55,6 +57,7 @@ def test_state_speaking_does_not_reset_index(personalApp: PersonalAppController)
 
 
 def test_sayAtIndex_stops_previous(personalApp: PersonalAppController):
+    personalApp._ensureTts()
     with (
         patch.object(personalApp._tts, "stop") as stop,
         patch.object(personalApp._tts, "say"),
@@ -86,6 +89,7 @@ def test_setTtsVoice_persists_to_settings(personalApp: PersonalAppController):
 
 
 def test_initTtsVoice_restores_saved(personalApp: PersonalAppController):
+    personalApp._ensureTts()
     voices = personalApp.ttsVoices
     if not voices:
         pytest.skip("No TTS voices available")
@@ -102,6 +106,7 @@ def test_openSystemVoiceSettings(personalApp: PersonalAppController):
 
 
 def test_previewVoice(personalApp: PersonalAppController):
+    personalApp._ensureTts()
     voices = personalApp.ttsVoices
     if not voices:
         pytest.skip("No TTS voices available")

--- a/pkdiagram/tests/views/eventform/test_eventform_clear.py
+++ b/pkdiagram/tests/views/eventform/test_eventform_clear.py
@@ -61,6 +61,15 @@ def test_clear_Shift(view):
     assert view.view.targetsEntries() == []
 
 
+def test_clear_resets_showTime(view):
+    view.set_kind(EventKind.Birth)
+    view.set_startDateTime(START_DATETIME)
+    view.item.setProperty("showTime", True)
+    assert view.item.property("showTime") == True
+    view.clickClearButton()
+    assert view.item.property("showTime") == False
+
+
 def test_clear_spouse_child(view):
     view.set_kind(EventKind.Birth)
     view.personPicker.set_new_person("John Done")


### PR DESCRIPTION
## Summary

- **FD-314**: PDP sheet now dismissible without accepting — tap the drag handle or the new ✕ button in the header to close without affecting pending items
- **FD-315**: Time field in Add Data Point form is hidden by default (most historical events have no time); an "Add time" button appears once a date is entered to reveal it; resets on clear
- **FD-316**: Already fixed in master (commit 268a684); no change needed in this branch
- **FD-317**: Cluster title no longer truncates in focused state — hero title bar anchors right to the event count text (not a fixed offset), and the cluster navigation prev/next controls switch from a fixed 160px column to a RowLayout that fills available width

## Test plan

- [ ] Open PDP sheet with pending items → tap the drag handle pill at top → sheet closes without accepting
- [ ] Open PDP sheet → tap ✕ button in header row → sheet closes without accepting
- [ ] Add Data Point form: open and confirm time field is hidden; enter a date → "Add time" button appears → tap it → time field shows
- [ ] Add Data Point form: enter date + show time → tap Clear → time field hides again
- [ ] Learn tab: focus a cluster with a long title (e.g. "Early Adulthood Anxiety and Relationships") → title shows fully in the hero title bar and in the prev/next navigation controls below the graph
- [ ] Cluster date ranges display correctly (start and end year both visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)