### PR TITLE
fix: PDP badge count decrements on individual accept/reject (FD-312)

### DIFF
--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -67,6 +67,12 @@ Page {
         }
     }
 
+    Connections {
+        target: pdpSheet
+        function onItemAccepted() { root.pdpCount = Math.max(0, root.pdpCount - 1) }
+        function onItemRejected() { root.pdpCount = Math.max(0, root.pdpCount - 1) }
+    }
+
     // Get current discussion summary for header title
     function currentDiscussionSummary() {
         if (personalApp && personalApp.discussions) {


### PR DESCRIPTION
## Summary

- `PersonalContainer.pdpCount` was only updated on `onPdpChanged` (server round-trip), so individual accept/reject never decremented the badge
- Added a `Connections` block in `PersonalContainer.qml` targeting `pdpSheet` that decrements `pdpCount` by 1 on each `itemAccepted` / `itemRejected` signal
- `Math.max(0, ...)` guards against underflow if signals fire unexpectedly
- Accept All behavior unchanged — it triggers `onPdpChanged` via server refresh, which resets count to 0

## Test plan

- [ ] Open PDPSheet with N pending items — badge shows N
- [ ] Accept one card — badge shows N-1
- [ ] Reject one card — badge shows N-2
- [ ] Accept/reject all cards individually — badge reaches 0 (hidden)
- [ ] Accept All — badge clears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)