### PR TITLE
FD-338: Rebuild diagram UI (deep re-extraction)

### DIFF
--- a/doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml
+++ b/doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml
@@ -1,0 +1,232 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+// FD-338 "Rebuild diagram" prototype (iteration A).
+// Run: uv run python bin/prototype.py doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml
+//
+// Demonstrates the three new pieces, all reusing existing house patterns:
+//   1. rebuildButton  — 28px circular icon button (mirrors extractButton), left of Extract.
+//   2. rebuildDialog  — cost-confirm modal (mirrors clearDataDialog) that CARRIES the
+//                       "Max fidelity" toggle, so the K choice rides on the confirm step
+//                       and the toolbar only gains one icon. TEMPORARY (remove post-pricing).
+//   3. LoadingOverlay determinate variant — progress bar + label driven by a 0-100 signal.
+Rectangle {
+    id: root
+    anchors.fill: parent
+    color: util.QML_WINDOW_BG
+
+    property string textColor: util.QML_TEXT_COLOR
+    property string secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property string itemBg: util.QML_ITEM_BG
+    property string borderColor: util.QML_ITEM_BORDER_COLOR
+    property string accentColor: util.IS_UI_DARK_MODE ? "#4495F7" : "#007AFF"
+
+    // ── Mock top bar fragment (Discuss tab) ──────────────────────────────────
+    Rectangle {
+        id: topBar
+        width: parent.width
+        height: util.QML_HEADER_HEIGHT
+        color: util.QML_HEADER_BG
+        anchors.top: parent.top
+
+        Text {
+            anchors.left: parent.left
+            anchors.leftMargin: 16
+            anchors.verticalCenter: parent.verticalCenter
+            text: "Discuss"
+            color: textColor
+            font.pixelSize: util.QML_TITLE_FONT_SIZE
+            font.bold: true
+        }
+
+        // Extract button (existing) — kept for spatial reference
+        Rectangle {
+            id: extractButton
+            anchors.right: parent.right
+            anchors.rightMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
+            width: 28; height: 28; radius: 14
+            color: accentColor
+            Canvas {
+                anchors.centerIn: parent; width: 14; height: 14
+                onPaint: {
+                    var ctx = getContext("2d"); ctx.clearRect(0,0,width,height)
+                    ctx.strokeStyle = "white"; ctx.lineWidth = 1.5; ctx.lineCap = "round"
+                    ctx.beginPath(); ctx.moveTo(7,1); ctx.lineTo(7,9); ctx.stroke()
+                    ctx.beginPath(); ctx.moveTo(3.5,6); ctx.lineTo(7,10); ctx.lineTo(10.5,6); ctx.stroke()
+                    ctx.beginPath(); ctx.moveTo(1,10); ctx.lineTo(1,13); ctx.lineTo(13,13); ctx.lineTo(13,10); ctx.stroke()
+                }
+            }
+        }
+
+        // NEW: Rebuild button — 28px circle, left of Extract, circular-arrows glyph.
+        Rectangle {
+            id: rebuildButton
+            objectName: "rebuildButton"
+            anchors.right: extractButton.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            width: 28; height: 28; radius: 14
+            color: util.IS_UI_DARK_MODE ? "#3A3938" : "#E9E9EB"
+            Canvas {
+                anchors.centerIn: parent; width: 16; height: 16
+                onPaint: {
+                    var ctx = getContext("2d"); ctx.clearRect(0,0,width,height)
+                    ctx.strokeStyle = root.textColor; ctx.lineWidth = 1.5; ctx.lineCap = "round"
+                    // two-thirds circular arc + arrowhead = "rebuild/refresh"
+                    ctx.beginPath(); ctx.arc(8,8,5.2,-0.6,3.6); ctx.stroke()
+                    ctx.beginPath(); ctx.moveTo(11.6,3.2); ctx.lineTo(13.2,5.2); ctx.lineTo(10.6,5.6); ctx.stroke()
+                }
+            }
+            MouseArea { anchors.fill: parent; onClicked: rebuildDialog.open() }
+        }
+    }
+
+    Text {
+        anchors.centerIn: parent
+        text: "Tap the rebuild glyph (top-right, left of Extract)\nto open the cost-confirm modal."
+        horizontalAlignment: Text.AlignHCenter
+        color: secondaryText
+        font.pixelSize: 14
+    }
+
+    // ── NEW: cost-confirm modal with embedded Max-fidelity toggle ─────────────
+    // TEMPORARY: remove this whole cost-confirmation dialog (and the cost copy)
+    // once a customer pricing model is added to the app. Until then it gates the
+    // spend and points the user at patrick@alaskafamilysystems.com.
+    property bool maxFidelity: true
+    Popup {
+        id: rebuildDialog
+        objectName: "rebuildDialog"
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: Math.min(root.width - 40, 340)
+        modal: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        padding: 0
+        background: Rectangle { radius: 14; color: itemBg; border.width: 1; border.color: borderColor }
+        enter: Transition {
+            NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 150 }
+            NumberAnimation { property: "scale"; from: 0.9; to: 1; duration: 150; easing.type: Easing.OutBack }
+        }
+        exit: Transition { NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 100 } }
+
+        contentItem: Column {
+            spacing: 0
+            padding: 20
+            width: rebuildDialog.width
+
+            Text {
+                text: "Rebuild Diagram"
+                font.pixelSize: 17; font.bold: true; color: textColor
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Item { width: 1; height: 12 }
+            Text {
+                width: rebuildDialog.width - 40
+                text: "This re-runs the AI several times to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about $0.50 each time. Please check with patrick@alaskafamilysystems.com before continuing."
+                wrapMode: Text.WordWrap
+                font.pixelSize: 14; color: secondaryText
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Item { width: 1; height: 18 }
+
+            // Max-fidelity toggle row (default ON = K=6). OFF = K=4.
+            Rectangle {
+                width: rebuildDialog.width - 40
+                height: 52; radius: 10
+                color: util.QML_ITEM_ALTERNATE_BG
+                anchors.horizontalCenter: parent.horizontalCenter
+                Column {
+                    anchors.left: parent.left; anchors.leftMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter; spacing: 2
+                    Text { text: "Max fidelity"; font.pixelSize: 15; color: textColor }
+                    Text {
+                        text: root.maxFidelity ? "Best accuracy, about $0.50" : "Faster, about $0.25"
+                        font.pixelSize: 11; color: secondaryText
+                    }
+                }
+                Switch {
+                    anchors.right: parent.right; anchors.rightMargin: 8
+                    anchors.verticalCenter: parent.verticalCenter
+                    checked: root.maxFidelity
+                    onToggled: root.maxFidelity = checked
+                }
+            }
+            Item { width: 1; height: 16 }
+
+            Row {
+                spacing: 10
+                anchors.horizontalCenter: parent.horizontalCenter
+                Rectangle {
+                    width: (rebuildDialog.width - 50) / 2; height: 44; radius: 10
+                    color: util.QML_ITEM_ALTERNATE_BG
+                    Text { anchors.centerIn: parent; text: "Cancel"; font.pixelSize: 15; color: textColor }
+                    MouseArea { anchors.fill: parent; onClicked: rebuildDialog.close() }
+                }
+                Rectangle {
+                    width: (rebuildDialog.width - 50) / 2; height: 44; radius: 10
+                    color: accentColor
+                    Text { anchors.centerIn: parent; text: "Continue"; font.pixelSize: 15; color: "white" }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            // production: personalApp.rebuildDiagram(root.maxFidelity ? 6 : 4)
+                            rebuildDialog.close()
+                            demoOverlay.progress = 0
+                            demoOverlay.text = "Rebuild 1 of " + (root.maxFidelity ? 6 : 4)
+                            demoOverlay.visible = true
+                            demoTimer.k = root.maxFidelity ? 6 : 4
+                            demoTimer.n = 0
+                            demoTimer.start()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── LoadingOverlay determinate variant (progress bar + label) ─────────────
+    Rectangle {
+        id: demoOverlay
+        property real progress: -1   // -1 = indeterminate (legacy importOverlay), >=0 = determinate
+        property string text: "Loading..."
+        anchors.fill: parent
+        visible: false
+        color: util.QML_HEADER_BG
+        z: 1000
+        MouseArea { anchors.fill: parent; onClicked: {} }
+        Column {
+            anchors.centerIn: parent
+            anchors.verticalCenterOffset: -42
+            spacing: 20; width: parent.width * 0.7
+            ProgressBar {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
+                from: 0; to: 100
+                indeterminate: demoOverlay.progress < 0
+                value: Math.max(0, demoOverlay.progress)
+            }
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: demoOverlay.text + (demoOverlay.progress >= 0 ? "  ·  " + Math.round(demoOverlay.progress) + "%" : "")
+                color: util.QML_TEXT_COLOR; font.pixelSize: 16
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+    }
+    Timer {
+        id: demoTimer
+        property int k: 6
+        property int n: 0
+        interval: 500; repeat: true
+        onTriggered: {
+            n += 1
+            demoOverlay.progress = Math.min(100, n / (k * 2) * 100)
+            demoOverlay.text = "Rebuild " + Math.min(k, Math.ceil(n / 2)) + " of " + k
+            if (demoOverlay.progress >= 100) { stop(); demoOverlay.visible = false }
+        }
+    }
+}

--- a/doc/ui-specs/rebuild-diagram.md
+++ b/doc/ui-specs/rebuild-diagram.md
@@ -36,14 +36,14 @@ Prototype: `doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml`.
 - Content (Column, padding 20):
   - Title "Rebuild Diagram" (17px bold).
   - Body (14px secondary, wrapped, no exclamation points): explains it re-runs the
-    AI several times to reconstruct a more complete diagram, costs Alaska Family
-    Systems about $0.50 each time, and to check with
+    AI to reconstruct a more complete diagram, costs Alaska Family
+    Systems about $0.10 ($0.60 max fidelity) each time, and to check with
     patrick@alaskafamilysystems.com before continuing.
   - **Max-fidelity row** (rounded `QML_ITEM_ALTERNATE_BG`): label "Max fidelity"
-    + caption that flips with state ("Best accuracy, about $0.50" when ON /
-    "Faster, about $0.25" when OFF) and a `Switch`, default **checked = K=6**.
+    + caption that flips with state ("Best accuracy, about $0.60" when ON /
+    "Faster, about $0.10" when OFF) and a `Switch`, default **unchecked = K=1**.
   - Buttons row: "Cancel" (neutral) closes; "Continue" (accent) calls
-    `personalApp.rebuildDiagram(maxFidelity ? 6 : 4)` then closes.
+    `personalApp.rebuildDiagram(maxFidelity ? 8 : 1)` then closes.
 - **In-code comment** above the dialog: `TEMPORARY: remove this cost-confirmation
   dialog once a customer pricing model is added to the app.`
 
@@ -82,6 +82,6 @@ Prototype: `doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml`.
   machine handles progress→complete (PDP applied, signals emitted) and
   progress→error (extractFailed), with the server mocked.
 - Component test: rebuild button opens modal; Continue invokes
-  `rebuildDiagram(6)` by default and `rebuildDiagram(4)` when toggle off.
+  `rebuildDiagram(1)` by default and `rebuildDiagram(8)` when toggle on.
 - Note (rules I017): the Personal app has no person/event list view — any check
   of the *committed* result after accept must be done in the Pro app.

--- a/doc/ui-specs/rebuild-diagram.md
+++ b/doc/ui-specs/rebuild-diagram.md
@@ -1,0 +1,87 @@
+# Feature: Rebuild Diagram (deep re-extraction) — FD-338
+
+## Purpose
+Let a Personal-app user reconstruct a more complete, better-connected family
+diagram from their discussions via async multi-sample consensus extraction. The
+result arrives as a PDP delta and is reviewed/accepted through the **existing**
+PDPSheet flow — no change to the accept/reject UI.
+
+Prototype: `doc/ui-prototyping/5-Rebuild-Diagram/1-rebuild-A.qml`.
+
+## Design decisions (constrained)
+- The new UI is three small additions, each reusing an existing house pattern.
+- The **fidelity toggle lives inside the cost modal**, not in the toolbar — so
+  the toolbar gains only one icon button and the K choice is part of the confirm
+  step.
+- The cost modal is **temporary**: it must carry an in-code comment to remove it
+  once a customer pricing model exists.
+
+## 1. Rebuild button (PersonalContainer.qml)
+- 28×28 circular `Rectangle` mirroring `extractButton` (~line 240).
+  `objectName: "rebuildButton"`. Anchored `right: extractButton.left`,
+  `rightMargin: 8`, vertically centered.
+- Glyph: circular-arrows ("rebuild") via `Canvas`, stroke = `util.QML_TEXT_COLOR`.
+- Neutral fill (`#3A3938` dark / `#E9E9EB` light) to distinguish from the blue
+  Extract action.
+- `visible: tabBar.currentIndex === 0 && !!personalApp && personalApp.canRebuild`
+  — new controller property; true when the current discussion has a diagram with
+  at least one discussion to rebuild from. (Independent of `canExtract`; a rebuild
+  is valid even with no unextracted statements.)
+- `MouseArea.onClicked: rebuildDialog.open()` — opens the modal; never enqueues
+  directly.
+
+## 2. Cost-confirm modal `rebuildDialog` (PersonalContainer.qml)
+- `Popup`, parent `Overlay.overlay`, `modal: true`, mirrors `clearDataDialog`
+  (~line 948): radius-14 `itemBg` background, OutBack enter, fade exit.
+- Content (Column, padding 20):
+  - Title "Rebuild Diagram" (17px bold).
+  - Body (14px secondary, wrapped, no exclamation points): explains it re-runs the
+    AI several times to reconstruct a more complete diagram, costs Alaska Family
+    Systems about $0.50 each time, and to check with
+    patrick@alaskafamilysystems.com before continuing.
+  - **Max-fidelity row** (rounded `QML_ITEM_ALTERNATE_BG`): label "Max fidelity"
+    + caption that flips with state ("Best accuracy, about $0.50" when ON /
+    "Faster, about $0.25" when OFF) and a `Switch`, default **checked = K=6**.
+  - Buttons row: "Cancel" (neutral) closes; "Continue" (accent) calls
+    `personalApp.rebuildDiagram(maxFidelity ? 6 : 4)` then closes.
+- **In-code comment** above the dialog: `TEMPORARY: remove this cost-confirmation
+  dialog once a customer pricing model is added to the app.`
+
+## 3. Progress overlay (LoadingOverlay.qml — shared component)
+- Add `property real progress: -1` (and keep `property string text`).
+  `progress < 0` → indeterminate spinner (legacy `importOverlay` behaviour,
+  unchanged). `progress >= 0` → determinate `ProgressBar` (0–100) + label with
+  percentage.
+- Driven by a new controller signal during a rebuild (e.g. `rebuildProgress(int
+  percent, string message)` where message is like "Rebuild 3 of 6").
+- Backward compatible: existing `importOverlay` sets only `text`, so `progress`
+  stays −1 and rendering is identical to today.
+
+## Lifecycle / states
+- **Idle**: rebuild button visible when `canRebuild`.
+- **Confirming**: modal open; fidelity toggle set; Cancel or Continue.
+- **Running**: overlay visible, determinate progress from status polling.
+- **Complete**: controller deserializes the PDP into `diagram_data.pdp`,
+  `setDiagramData`, emits `pdpChanged` + `extractCompleted` → existing
+  `DiscussView.onExtractCompleted` opens the PDPSheet (reused).
+- **Error / empty**: reuse existing `extractFailed` / "Nothing New" paths.
+
+## Controller (personalappcontroller.py) — Python, not QML JS
+- `canRebuild` (pyqtProperty/notify) — gating per above.
+- `rebuildDiagram(int k)` — POST `/personal/discussions/<id>/deep-reextract`
+  `{k}`; on `task_id`, begin polling `GET
+  /personal/discussions/<id>/deep-reextract-status/<task_id>`; emit
+  `extractStarted` + set overlay determinate.
+- Poll handler: on PROGRESS emit `rebuildProgress`; on complete, deserialize
+  `pdp`, `setDiagramData`, emit `pdpChanged` + `extractCompleted`; on error emit
+  `extractFailed`. Reuse the existing async non-blocking request + the
+  AssemblyAI-style polling pattern already in the controller.
+
+## Tests
+- Controller unit test: `rebuildDiagram` posts with the right k; polling state
+  machine handles progress→complete (PDP applied, signals emitted) and
+  progress→error (extractFailed), with the server mocked.
+- Component test: rebuild button opens modal; Continue invokes
+  `rebuildDiagram(6)` by default and `rebuildDiagram(4)` when toggle off.
+- Note (rules I017): the Personal app has no person/event list view — any check
+  of the *committed* result after accept must be done in the Pro app.

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -10,8 +10,10 @@ from btcopilot.schema import (
     EventKind,
     DiagramData,
     PDP,
+    Person as SchemaPerson,
     asdict,
     from_dict,
+    is_parents_edit,
     VariableShift,
     RelationshipKind,
     DateCertainty,
@@ -1152,6 +1154,16 @@ class PersonalAppController(QObject):
             from_root=True,
         )
 
+    @staticmethod
+    def _pdpDrained(diagramData: DiagramData) -> bool:
+        """Parents-only edit rows are the server-applied channel (applied by
+        commit-pdp on full accept), so they never block a full accept."""
+        return not (
+            any(not is_parents_edit(p) for p in diagramData.pdp.people)
+            or diagramData.pdp.events
+            or diagramData.pdp.pair_bonds
+        )
+
     def _doAcceptPDPItem(self, id: int) -> bool:
         _log.info(f"Accepting PDP item with id: {id}")
 
@@ -1184,11 +1196,7 @@ class PersonalAppController(QObject):
             committedItems["pair_bonds"] = [
                 pb for pb in diagramData.pair_bonds if pb["id"] not in prevPairBondIds
             ]
-            drained["v"] = not (
-                diagramData.pdp.people
-                or diagramData.pdp.events
-                or diagramData.pdp.pair_bonds
-            )
+            drained["v"] = self._pdpDrained(diagramData)
 
             return diagramData
 
@@ -1279,7 +1287,7 @@ class PersonalAppController(QObject):
     def _doHandleCommittedItem(self, id: int, accept: bool, undo: bool = True) -> bool:
         """Accept or reject a committed item (positive id in pdp.people or pdp.delete)."""
         prev_data = self._diagram.getDiagramData() if undo else None
-        result: dict = {"is_delete": False, "edit_fields": {}}
+        result: dict = {"is_delete": False, "edit_fields": {}, "drained": False}
 
         def applyChange(diagramData: DiagramData):
             if not diagramData.pdp:
@@ -1304,6 +1312,7 @@ class PersonalAppController(QObject):
                     diagramData.reject_committed_delete(id)
                 else:
                     diagramData.reject_committed_edit(id)
+            result["drained"] = self._pdpDrained(diagramData)
             return diagramData
 
         success = self._diagram.save(
@@ -1324,6 +1333,10 @@ class PersonalAppController(QObject):
                         if "gender" in result["edit_fields"]:
                             person.setGender(result["edit_fields"]["gender"])
             self.pdpChanged.emit()
+            if accept:
+                # The route acknowledges echoed positive ids as no-ops; the
+                # flag is what advances the cursor when this was the last card.
+                self._postCommitPdp([id], result["drained"])
             if undo and prev_data:
                 action = PDPAction.Accept if accept else PDPAction.Reject
                 self._undoStack.push(HandlePDPItem(action, self, id, prev_data))
@@ -1398,6 +1411,12 @@ class PersonalAppController(QObject):
         return {}
 
     # PDP helper slots - model lookups and enum mappings
+
+    @pyqtSlot("QVariantMap", result=bool)
+    def isParentsEdit(self, person: dict) -> bool:
+        """Parents-only rows render no card; PDPSheet and the badge count both
+        filter through this so they can't disagree."""
+        return is_parents_edit(from_dict(SchemaPerson, person))
 
     @pyqtSlot(int, result=str)
     @pyqtSlot("QVariant", result=str)
@@ -1559,7 +1578,9 @@ class PersonalAppController(QObject):
                     newIds.append(pair_bond.id)
 
             committedEdits = [
-                p for p in diagramData.pdp.people if p.id is not None and p.id > 0
+                p
+                for p in diagramData.pdp.people
+                if p.id is not None and p.id > 0 and not is_parents_edit(p)
             ]
             deleteIds = list(diagramData.pdp.delete or [])
 
@@ -1615,11 +1636,7 @@ class PersonalAppController(QObject):
                 for del_id in deleteIds:
                     diagramData.accept_committed_delete(del_id)
 
-                drained["v"] = not (
-                    diagramData.pdp.people
-                    or diagramData.pdp.events
-                    or diagramData.pdp.pair_bonds
-                )
+                drained["v"] = self._pdpDrained(diagramData)
                 return diagramData
 
             success = self._diagram.save(

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -40,7 +40,11 @@ from pkdiagram.pyqt import (
     QUndoStack,
     QVariant,
 )
-from PyQt5.QtCore import QLocale, QByteArray, QTimer
+from PyQt5.QtCore import QLocale, QByteArray, QTimer, QDateTime
+
+# Rebuild fails if no progress advance arrives within this window — catches a
+# crashed/killed worker or a lost task, which otherwise poll a dead task forever.
+REBUILD_STALL_MS = 180_000
 from pkdiagram.app import Session, Analytics
 from pkdiagram.personal.models import Discussion
 from pkdiagram.server_types import Diagram
@@ -75,6 +79,13 @@ class PersonalAppController(QObject):
     extractCompleted = pyqtSignal(QVariant, arguments=["summary"])
     extractFailed = pyqtSignal(str, arguments=["error"])
     rebuildProgress = pyqtSignal(int, str, arguments=["percent", "message"])
+    rebuildCancelled = pyqtSignal()
+
+    # Rebuild watchdog/cancel state (set live by rebuildDiagram); 0 = inactive.
+    _rebuildLastProgressMs = 0
+    _rebuildPrevCurrent = -1
+    _rebuildTaskId = ""
+    _rebuildCancelled = False
 
     ttsPlayingIndexChanged = pyqtSignal()
     ttsFinished = pyqtSignal()
@@ -1848,6 +1859,14 @@ class PersonalAppController(QObject):
 
         discussionId = self._currentDiscussion.id
 
+        # Watchdog / cancel state for this run. A frozen task never advances,
+        # so the poller fails it after REBUILD_STALL_MS instead of spinning
+        # forever; cancel stops the poll loop and tells the server to abort.
+        self._rebuildLastProgressMs = QDateTime.currentMSecsSinceEpoch()
+        self._rebuildPrevCurrent = -1
+        self._rebuildCancelled = False
+        self._rebuildTaskId = ""
+
         # Set overlay to determinate mode at 0 before showing
         self.rebuildProgress.emit(0, "Starting rebuild...")
         self.extractStarted.emit()
@@ -1857,6 +1876,7 @@ class PersonalAppController(QObject):
             if not taskId:
                 self.extractFailed.emit("Server did not return a task ID")
                 return
+            self._rebuildTaskId = taskId
             self._pollRebuild(discussionId, taskId)
 
         def onError():
@@ -1874,13 +1894,21 @@ class PersonalAppController(QObject):
 
     def _pollRebuild(self, discussionId: int, taskId: str):
         def onSuccess(data):
+            if self._rebuildCancelled:
+                return
             status = data.get("status", "")
+            now = QDateTime.currentMSecsSinceEpoch()
             if status == "progress":
                 current = data.get("current", 0)
                 total = data.get("total", 1)
                 label = data.get("label", "Rebuilding...")
                 percent = round(current / total * 100) if total else 0
+                if current > self._rebuildPrevCurrent:
+                    self._rebuildPrevCurrent = current
+                    self._rebuildLastProgressMs = now
                 self.rebuildProgress.emit(percent, label)
+                if self._rebuildStalled(now):
+                    return
                 QTimer.singleShot(1000, lambda: self._pollRebuild(discussionId, taskId))
             elif status == "complete":
                 if self._diagram:
@@ -1910,7 +1938,9 @@ class PersonalAppController(QObject):
             elif status == "error":
                 self.extractFailed.emit(data.get("error", "Rebuild failed"))
             else:
-                # pending or unknown — keep polling
+                # pending or unknown — keep polling unless it has gone stale
+                if self._rebuildStalled(now):
+                    return
                 QTimer.singleShot(1000, lambda: self._pollRebuild(discussionId, taskId))
 
         def onError():
@@ -1925,3 +1955,41 @@ class PersonalAppController(QObject):
             headers={"Content-Type": "application/json", "Accept": "application/json"},
             from_root=True,
         )
+
+    def _rebuildStalled(self, now_ms: int) -> bool:
+        """True (and emits the failure) if no progress has advanced within
+        REBUILD_STALL_MS — i.e. the worker crashed/was killed or the task was
+        lost. Stops the poll loop so the overlay can't spin on a dead task."""
+        if self._rebuildLastProgressMs <= 0:
+            return False  # no rebuild active
+        if now_ms - self._rebuildLastProgressMs <= REBUILD_STALL_MS:
+            return False
+        self.extractFailed.emit(
+            "The rebuild stopped responding — the server may have crashed. "
+            "Please try again."
+        )
+        return True
+
+    @pyqtSlot()
+    def cancelRebuild(self):
+        """Stop polling, tell the server to abort the background task and release
+        the lock, and dismiss the overlay. Quitting the app has the same
+        server-side effect: polling stops, the heartbeat expires, and the worker
+        aborts the run on its own — so no orphaned rebuild keeps running."""
+        self._rebuildCancelled = True
+        taskId = self._rebuildTaskId
+        discussionId = self._currentDiscussion.id if self._currentDiscussion else None
+        if taskId and discussionId:
+            self.session.server().nonBlockingRequest(
+                "POST",
+                f"/personal/discussions/{discussionId}/deep-reextract/{taskId}/cancel",
+                data={},
+                error=lambda: None,
+                success=lambda d: None,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                from_root=True,
+            )
+        self.rebuildCancelled.emit()

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -40,7 +40,7 @@ from pkdiagram.pyqt import (
     QUndoStack,
     QVariant,
 )
-from PyQt5.QtCore import QLocale, QByteArray
+from PyQt5.QtCore import QLocale, QByteArray, QTimer
 from pkdiagram.app import Session, Analytics
 from pkdiagram.personal.models import Discussion
 from pkdiagram.server_types import Diagram
@@ -74,6 +74,7 @@ class PersonalAppController(QObject):
     extractStarted = pyqtSignal()
     extractCompleted = pyqtSignal(QVariant, arguments=["summary"])
     extractFailed = pyqtSignal(str, arguments=["error"])
+    rebuildProgress = pyqtSignal(int, str, arguments=["percent", "message"])
 
     ttsPlayingIndexChanged = pyqtSignal()
     ttsFinished = pyqtSignal()
@@ -692,9 +693,6 @@ class PersonalAppController(QObject):
         self._pollTranscription(transcriptId, apiKey, filePath)
 
     def _pollTranscription(self, transcriptId: str, apiKey: str, filePath: str):
-        """Poll AssemblyAI for transcription completion."""
-        from PyQt5.QtCore import QTimer
-
         pollUrl = QUrl(f"https://api.assemblyai.com/v2/transcript/{transcriptId}")
         pollRequest = QNetworkRequest(pollUrl)
         pollRequest.setRawHeader(
@@ -713,9 +711,6 @@ class PersonalAppController(QObject):
         apiKey: str,
         filePath: str,
     ):
-        """Handle poll response; re-poll if still processing."""
-        from PyQt5.QtCore import QTimer
-
         error = reply.error()
         if error != QNetworkReply.NoError:
             errorMsg = reply.errorString()
@@ -942,6 +937,19 @@ class PersonalAppController(QObject):
         - partial accept / extract-without-accept: unchanged."""
         return bool(self._currentDiscussion) and self._dirty
 
+    @pyqtProperty(bool, notify=pdpChanged)
+    def canRebuild(self) -> bool:
+        """Rebuild button visibility. True when there is a current discussion
+        AND the diagram already has at least one person (something to rebuild
+        from). Independent of canExtract — a rebuild is valid even when the
+        conversation is fully extracted."""
+        if not self._currentDiscussion or not self._diagram:
+            return False
+        if self.scene and self.scene.people():
+            return True
+        diagramData = self._diagram.getDiagramData()
+        return bool(diagramData.people)
+
     @pyqtSlot()
     def createDiscussion(self):
         self._createDiscussion()
@@ -1060,7 +1068,9 @@ class PersonalAppController(QObject):
     @pyqtSlot(int, result=bool)
     def acceptPDPItem(self, id: int, undo=True):
         if id > 0:
-            return self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True, undo=undo))
+            return self._withSaveGuard(
+                lambda: self._doHandleCommittedItem(id, accept=True, undo=undo)
+            )
         if id == 0:
             _log.error(f"acceptPDPItem called with id 0, ignoring")
             return False
@@ -1080,7 +1090,9 @@ class PersonalAppController(QObject):
     @pyqtSlot(int, result=bool)
     def rejectPDPItem(self, id: int, undo=True):
         if id > 0:
-            return self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False, undo=undo))
+            return self._withSaveGuard(
+                lambda: self._doHandleCommittedItem(id, accept=False, undo=undo)
+            )
         if id == 0:
             _log.error(f"rejectPDPItem called with id 0, ignoring")
             return False
@@ -1267,7 +1279,9 @@ class PersonalAppController(QObject):
                 if is_delete:
                     diagramData.accept_committed_delete(id)
                 else:
-                    pdp_person = next((p for p in diagramData.pdp.people if p.id == id), None)
+                    pdp_person = next(
+                        (p for p in diagramData.pdp.people if p.id == id), None
+                    )
                     if pdp_person is not None:
                         if pdp_person.name is not None:
                             result["edit_fields"]["name"] = pdp_person.name
@@ -1309,19 +1323,27 @@ class PersonalAppController(QObject):
 
     @pyqtSlot(int, result=bool)
     def acceptCommittedEdit(self, id: int) -> bool:
-        return bool(self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True)))
+        return bool(
+            self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True))
+        )
 
     @pyqtSlot(int, result=bool)
     def rejectCommittedEdit(self, id: int) -> bool:
-        return bool(self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False)))
+        return bool(
+            self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False))
+        )
 
     @pyqtSlot(int, result=bool)
     def acceptCommittedDelete(self, id: int) -> bool:
-        return bool(self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True)))
+        return bool(
+            self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=True))
+        )
 
     @pyqtSlot(int, result=bool)
     def rejectCommittedDelete(self, id: int) -> bool:
-        return bool(self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False)))
+        return bool(
+            self._withSaveGuard(lambda: self._doHandleCommittedItem(id, accept=False))
+        )
 
     def _doRejectPDPItem(self, id: int) -> bool:
         _log.info(f"Rejecting PDP item with id: {id}")
@@ -1525,14 +1547,18 @@ class PersonalAppController(QObject):
                 if pair_bond.id is not None and pair_bond.id < 0:
                     newIds.append(pair_bond.id)
 
-            committedEdits = [p for p in diagramData.pdp.people if p.id is not None and p.id > 0]
+            committedEdits = [
+                p for p in diagramData.pdp.people if p.id is not None and p.id > 0
+            ]
             deleteIds = list(diagramData.pdp.delete or [])
 
             if not newIds and not committedEdits and not deleteIds:
                 self._postCommitPdp([], True)
                 return
 
-            _log.info(f"Accepting all PDP items: new={newIds}, edits={[p.id for p in committedEdits]}, deletes={deleteIds}")
+            _log.info(
+                f"Accepting all PDP items: new={newIds}, edits={[p.id for p in committedEdits]}, deletes={deleteIds}"
+            )
 
             newItems = {"people": [], "events": [], "pair_bonds": [], "emotions": []}
             editFields: dict[int, dict] = {}
@@ -1552,22 +1578,36 @@ class PersonalAppController(QObject):
                     prevEventIds = {e["id"] for e in diagramData.events}
                     prevPairBondIds = {pb["id"] for pb in diagramData.pair_bonds}
                     diagramData.commit_pdp_items(newIds)
-                    newItems["people"] = [p for p in diagramData.people if p["id"] not in prevPeopleIds]
-                    newItems["events"] = [e for e in diagramData.events if e["id"] not in prevEventIds]
-                    newItems["pair_bonds"] = [pb for pb in diagramData.pair_bonds if pb["id"] not in prevPairBondIds]
+                    newItems["people"] = [
+                        p for p in diagramData.people if p["id"] not in prevPeopleIds
+                    ]
+                    newItems["events"] = [
+                        e for e in diagramData.events if e["id"] not in prevEventIds
+                    ]
+                    newItems["pair_bonds"] = [
+                        pb
+                        for pb in diagramData.pair_bonds
+                        if pb["id"] not in prevPairBondIds
+                    ]
 
                 for pdp_person in committedEdits:
                     if pdp_person.name is not None:
-                        editFields.setdefault(pdp_person.id, {})["name"] = pdp_person.name
+                        editFields.setdefault(pdp_person.id, {})[
+                            "name"
+                        ] = pdp_person.name
                     if pdp_person.gender is not None:
-                        editFields.setdefault(pdp_person.id, {})["gender"] = pdp_person.gender
+                        editFields.setdefault(pdp_person.id, {})[
+                            "gender"
+                        ] = pdp_person.gender
                     diagramData.accept_committed_edit(pdp_person.id)
 
                 for del_id in deleteIds:
                     diagramData.accept_committed_delete(del_id)
 
                 drained["v"] = not (
-                    diagramData.pdp.people or diagramData.pdp.events or diagramData.pdp.pair_bonds
+                    diagramData.pdp.people
+                    or diagramData.pdp.events
+                    or diagramData.pdp.pair_bonds
                 )
                 return diagramData
 
@@ -1788,6 +1828,97 @@ class PersonalAppController(QObject):
         reply = self.session.server().nonBlockingRequest(
             "POST",
             f"/personal/discussions/{self._currentDiscussion.id}/extract",
+            data={},
+            error=onError,
+            success=onSuccess,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            from_root=True,
+        )
+
+    ## Rebuild (deep re-extraction)
+
+    @pyqtSlot(int)
+    def rebuildDiagram(self, k: int):
+        if not self._currentDiscussion:
+            self.extractFailed.emit("No discussion selected")
+            return
+        if not self._diagram:
+            self.extractFailed.emit("No diagram loaded")
+            return
+
+        discussionId = self._currentDiscussion.id
+
+        # Set overlay to determinate mode at 0 before showing
+        self.rebuildProgress.emit(0, "Starting rebuild...")
+        self.extractStarted.emit()
+
+        def onSuccess(data):
+            taskId = data.get("task_id", "")
+            if not taskId:
+                self.extractFailed.emit("Server did not return a task ID")
+                return
+            self._pollRebuild(discussionId, taskId)
+
+        def onError():
+            self.extractFailed.emit(reply.errorString())
+
+        reply = self.session.server().nonBlockingRequest(
+            "POST",
+            f"/personal/discussions/{discussionId}/deep-reextract",
+            data={"k": k},
+            error=onError,
+            success=onSuccess,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            from_root=True,
+        )
+
+    def _pollRebuild(self, discussionId: int, taskId: str):
+        def onSuccess(data):
+            status = data.get("status", "")
+            if status == "progress":
+                current = data.get("current", 0)
+                total = data.get("total", 1)
+                label = data.get("label", "Rebuilding...")
+                percent = round(current / total * 100) if total else 0
+                self.rebuildProgress.emit(percent, label)
+                QTimer.singleShot(1000, lambda: self._pollRebuild(discussionId, taskId))
+            elif status == "complete":
+                if self._diagram:
+                    rebuilt_pdp = from_dict(PDP, data["pdp"])
+
+                    def _do():
+                        def applyChange(diagramData: DiagramData):
+                            diagramData.pdp = rebuilt_pdp
+                            return diagramData
+
+                        self._diagram.save(
+                            self.session.server(),
+                            applyChange,
+                            lambda d: True,
+                            useJson=True,
+                        )
+
+                    self._withSaveGuard(_do)
+                self.pdpChanged.emit()
+                self.extractCompleted.emit(
+                    {
+                        "people": data.get("people_count", 0),
+                        "events": data.get("events_count", 0),
+                        "pairBonds": data.get("pair_bonds_count", 0),
+                    }
+                )
+            elif status == "error":
+                self.extractFailed.emit(data.get("error", "Rebuild failed"))
+            else:
+                # pending or unknown — keep polling
+                QTimer.singleShot(1000, lambda: self._pollRebuild(discussionId, taskId))
+
+        def onError():
+            self.extractFailed.emit(pollReply.errorString())
+
+        pollReply = self.session.server().nonBlockingRequest(
+            "GET",
+            f"/personal/discussions/{discussionId}/deep-reextract-status/{taskId}",
             data={},
             error=onError,
             success=onSuccess,

--- a/pkdiagram/resources/qml/Personal/DiscussView.qml
+++ b/pkdiagram/resources/qml/Personal/DiscussView.qml
@@ -134,12 +134,14 @@ Page {
             // rebuild path; leave it as-is so the determinate bar is shown.
             if (extractOverlay.progress < 0) {
                 extractOverlay.text = "Detecting data..."
+                extractOverlay.cancellable = false
             }
             extractOverlay.visible = true
         }
         function onExtractCompleted(summary) {
             extractOverlay.visible = false
             extractOverlay.progress = -1
+            extractOverlay.cancellable = false
             var total = (summary.people || 0) + (summary.events || 0) + (summary.pairBonds || 0)
             if (total > 0) {
                 pdpSheet.open()
@@ -152,12 +154,19 @@ Page {
         function onExtractFailed(error) {
             extractOverlay.visible = false
             extractOverlay.progress = -1
+            extractOverlay.cancellable = false
             util.criticalBox("Extraction Failed", error)
         }
         function onRebuildProgress(percent, message) {
             extractOverlay.progress = percent
             extractOverlay.text = message
+            extractOverlay.cancellable = true
             extractOverlay.visible = true
+        }
+        function onRebuildCancelled() {
+            extractOverlay.visible = false
+            extractOverlay.progress = -1
+            extractOverlay.cancellable = false
         }
     }
 
@@ -769,5 +778,6 @@ Page {
         id: extractOverlay
         objectName: "extractOverlay"
         text: "Detecting data..."
+        onCancelClicked: personalApp.cancelRebuild()
     }
 }

--- a/pkdiagram/resources/qml/Personal/DiscussView.qml
+++ b/pkdiagram/resources/qml/Personal/DiscussView.qml
@@ -130,10 +130,16 @@ Page {
             }
         }
         function onExtractStarted() {
+            // progress may already be set to 0 by onRebuildProgress for the
+            // rebuild path; leave it as-is so the determinate bar is shown.
+            if (extractOverlay.progress < 0) {
+                extractOverlay.text = "Detecting data..."
+            }
             extractOverlay.visible = true
         }
         function onExtractCompleted(summary) {
             extractOverlay.visible = false
+            extractOverlay.progress = -1
             var total = (summary.people || 0) + (summary.events || 0) + (summary.pairBonds || 0)
             if (total > 0) {
                 pdpSheet.open()
@@ -145,7 +151,13 @@ Page {
         }
         function onExtractFailed(error) {
             extractOverlay.visible = false
+            extractOverlay.progress = -1
             util.criticalBox("Extraction Failed", error)
+        }
+        function onRebuildProgress(percent, message) {
+            extractOverlay.progress = percent
+            extractOverlay.text = message
+            extractOverlay.visible = true
         }
     }
 

--- a/pkdiagram/resources/qml/Personal/LoadingOverlay.qml
+++ b/pkdiagram/resources/qml/Personal/LoadingOverlay.qml
@@ -6,6 +6,9 @@ Rectangle {
     id: root
 
     property string text: "Loading..."
+    // progress < 0: indeterminate spinner (legacy importOverlay behaviour, unchanged).
+    // progress >= 0: determinate ProgressBar (0-100) + percent label.
+    property real progress: -1
 
     parent: Overlay.overlay
     anchors.fill: parent
@@ -23,11 +26,13 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.verticalCenterOffset: -42
         spacing: 20
+        width: parent.width * 0.7
 
         BusyIndicator {
             id: busyIndicator
             anchors.horizontalCenter: parent.horizontalCenter
-            running: root.visible
+            running: root.visible && root.progress < 0
+            visible: root.progress < 0
             width: 64
             height: 64
             contentItem: Item {
@@ -62,11 +67,20 @@ Rectangle {
             }
         }
 
+        ProgressBar {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            visible: root.progress >= 0
+            from: 0; to: 100
+            value: Math.max(0, root.progress)
+        }
+
         PK.Text {
             anchors.horizontalCenter: parent.horizontalCenter
-            text: root.text
+            text: root.progress >= 0 ? root.text + "  ·  " + Math.round(root.progress) + "%" : root.text
             color: util.QML_TEXT_COLOR
             font.pixelSize: 16
+            horizontalAlignment: Text.AlignHCenter
         }
     }
 }

--- a/pkdiagram/resources/qml/Personal/LoadingOverlay.qml
+++ b/pkdiagram/resources/qml/Personal/LoadingOverlay.qml
@@ -9,6 +9,9 @@ Rectangle {
     // progress < 0: indeterminate spinner (legacy importOverlay behaviour, unchanged).
     // progress >= 0: determinate ProgressBar (0-100) + percent label.
     property real progress: -1
+    // When true, show a Cancel button (used by the long rebuild) that emits cancelClicked().
+    property bool cancellable: false
+    signal cancelClicked()
 
     parent: Overlay.overlay
     anchors.fill: parent
@@ -68,11 +71,28 @@ Rectangle {
         }
 
         ProgressBar {
+            id: progressBar
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
+            height: 6
             visible: root.progress >= 0
             from: 0; to: 100
             value: Math.max(0, root.progress)
+            // Explicit track + fill so the bar is visible on the dark overlay
+            // (the default style's track blends into QML_HEADER_BG).
+            background: Rectangle {
+                implicitHeight: 6
+                radius: 3
+                color: util.IS_UI_DARK_MODE ? "#4d4c4c" : "#d8d8d8"
+            }
+            contentItem: Item {
+                Rectangle {
+                    width: progressBar.visualPosition * progressBar.width
+                    height: parent.height
+                    radius: 3
+                    color: util.QML_SELECTION_COLOR
+                }
+            }
         }
 
         PK.Text {
@@ -81,6 +101,26 @@ Rectangle {
             color: util.QML_TEXT_COLOR
             font.pixelSize: 16
             horizontalAlignment: Text.AlignHCenter
+        }
+
+        Rectangle {
+            objectName: "rebuildOverlayCancelButton"
+            anchors.horizontalCenter: parent.horizontalCenter
+            visible: root.cancellable
+            width: 130
+            height: 40
+            radius: 10
+            color: util.QML_ITEM_ALTERNATE_BG
+            PK.Text {
+                anchors.centerIn: parent
+                text: "Cancel"
+                color: util.QML_TEXT_COLOR
+                font.pixelSize: 15
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: root.cancelClicked()
+            }
         }
     }
 }

--- a/pkdiagram/resources/qml/Personal/PDPSheet.qml
+++ b/pkdiagram/resources/qml/Personal/PDPSheet.qml
@@ -68,7 +68,12 @@ Drawer {
         // is never empty when the PDP has content.
         if (pdp.people) {
             for (var i = 0; i < pdp.people.length; i++) {
-                var pid = pdp.people[i].id
+                var person = pdp.people[i]
+                var pid = person.id
+                // Parents-only edit rows are applied by the server on full
+                // accept, not reviewed as cards.
+                if (personalApp && personalApp.isParentsEdit(person))
+                    continue
                 itemsModel.append({
                     "itemType": pid > 0 ? "committed_edit" : "person",
                     "itemId": pid

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -133,6 +133,7 @@ Page {
 
         // Discussion title (tappable dropdown) - only on Discuss tab
         Rectangle {
+            objectName: "discussionHeaderDropdown"
             anchors.centerIn: parent
             width: titleRow.width + 16
             height: 36
@@ -610,6 +611,7 @@ Page {
             }
 
             Rectangle {
+                objectName: "newDiscussionItem"
                 width: parent.width - 16
                 height: 44
                 radius: 8
@@ -1183,6 +1185,7 @@ Page {
                 }
 
                 Switch {
+                    objectName: "rebuildMaxFidelitySwitch"
                     anchors.right: parent.right
                     anchors.rightMargin: 8
                     anchors.verticalCenter: parent.verticalCenter
@@ -1198,6 +1201,7 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 Rectangle {
+                    objectName: "rebuildCancelButton"
                     width: (rebuildDialog.width - 50) / 2
                     height: 44
                     radius: 10
@@ -1215,6 +1219,7 @@ Page {
                 }
 
                 Rectangle {
+                    objectName: "rebuildContinueButton"
                     width: (rebuildDialog.width - 50) / 2
                     height: 44
                     radius: 10

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -57,8 +57,14 @@ Page {
                 // Every PDP entry is a reviewable pending change; the badge
                 // must match the card count in PDPSheet (people + pair bonds
                 // + events), or a non-empty PDP can show a "0" badge.
+                // Parents-only edit rows render no card (PDPSheet filter).
                 var count = 0
-                if (pdp.people) count += pdp.people.length
+                if (pdp.people) {
+                    for (var i = 0; i < pdp.people.length; i++) {
+                        if (!personalApp.isParentsEdit(pdp.people[i]))
+                            count += 1
+                    }
+                }
                 if (pdp.pair_bonds) count += pdp.pair_bonds.length
                 if (pdp.events) count += pdp.events.length
                 if (pdp.delete) count += pdp.delete.length
@@ -1149,7 +1155,7 @@ Page {
 
             Text {
                 width: rebuildDialog.width - 40
-                text: "This re-runs the AI several times to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about " + (root.maxFidelity ? "$0.60" : "$0.30") + " each time. Please check with patrick@alaskafamilysystems.com before continuing."
+                text: "This re-runs the AI to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about " + (root.maxFidelity ? "$0.60" : "$0.10") + " each time. Please check with patrick@alaskafamilysystems.com before continuing."
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
                 color: secondaryText
@@ -1178,7 +1184,7 @@ Page {
                         color: textColor
                     }
                     Text {
-                        text: root.maxFidelity ? "Best accuracy, about $0.60" : "Faster, about $0.30"
+                        text: root.maxFidelity ? "Best accuracy, about $0.60" : "Faster, about $0.10"
                         font.pixelSize: 11
                         color: secondaryText
                     }
@@ -1233,7 +1239,7 @@ Page {
                     MouseArea {
                         anchors.fill: parent
                         onClicked: {
-                            personalApp.rebuildDiagram(root.maxFidelity ? 8 : 4)
+                            personalApp.rebuildDiagram(root.maxFidelity ? 8 : 1)
                             rebuildDialog.close()
                         }
                     }

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -209,11 +209,11 @@ Page {
             visible: tabBar.currentIndex === 2
         }
 
-        // PDP Badge (Discuss tab, left of extract button)
+        // PDP Badge (Discuss tab, left of rebuild button if visible, else left of extract button)
         Rectangle {
             id: pdpBadge
             objectName: "pdpBadge"
-            anchors.right: extractButton.left
+            anchors.right: rebuildButton.visible ? rebuildButton.left : extractButton.left
             anchors.rightMargin: 8
             anchors.verticalCenter: parent.verticalCenter
             width: 28
@@ -232,6 +232,44 @@ Page {
             MouseArea {
                 anchors.fill: parent
                 onClicked: pdpSheet.open()
+            }
+        }
+
+        // Rebuild button (Discuss tab, when canRebuild — left of extract button)
+        Rectangle {
+            id: rebuildButton
+            objectName: "rebuildButton"
+            anchors.right: extractButton.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            width: 28
+            height: 28
+            radius: 14
+            color: util.IS_UI_DARK_MODE ? "#3A3938" : "#E9E9EB"
+            visible: tabBar.currentIndex === 0 && !!personalApp && personalApp.canRebuild
+            Canvas {
+                anchors.centerIn: parent
+                width: 16
+                height: 16
+                onPaint: {
+                    var ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+                    ctx.strokeStyle = textColor
+                    ctx.lineWidth = 1.5
+                    ctx.lineCap = "round"
+                    ctx.beginPath()
+                    ctx.arc(8, 8, 5.2, -0.6, 3.6)
+                    ctx.stroke()
+                    ctx.beginPath()
+                    ctx.moveTo(11.6, 3.2)
+                    ctx.lineTo(13.2, 5.2)
+                    ctx.lineTo(10.6, 5.6)
+                    ctx.stroke()
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: rebuildDialog.open()
             }
         }
 
@@ -1060,6 +1098,140 @@ Page {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: clearDataDialog.close()
+                }
+            }
+        }
+    }
+
+    // TEMPORARY: remove this cost-confirmation dialog once a customer pricing model is added to the app.
+    property bool maxFidelity: true
+    Popup {
+        id: rebuildDialog
+        objectName: "rebuildDialog"
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: Math.min(root.width - 40, 340)
+        modal: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        padding: 0
+
+        background: Rectangle {
+            radius: 14
+            color: itemBg
+            border.width: 1
+            border.color: borderColor
+        }
+
+        enter: Transition {
+            NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 150 }
+            NumberAnimation { property: "scale"; from: 0.9; to: 1; duration: 150; easing.type: Easing.OutBack }
+        }
+        exit: Transition {
+            NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 100 }
+        }
+
+        contentItem: Column {
+            spacing: 0
+            padding: 20
+            width: rebuildDialog.width
+
+            Text {
+                text: "Rebuild Diagram"
+                font.pixelSize: 17
+                font.bold: true
+                color: textColor
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Item { width: 1; height: 12 }
+
+            Text {
+                width: rebuildDialog.width - 40
+                text: "This re-runs the AI several times to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about $0.60 each time. Please check with patrick@alaskafamilysystems.com before continuing."
+                wrapMode: Text.WordWrap
+                font.pixelSize: 14
+                color: secondaryText
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Item { width: 1; height: 18 }
+
+            Rectangle {
+                width: rebuildDialog.width - 40
+                height: 52
+                radius: 10
+                color: util.QML_ITEM_ALTERNATE_BG
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                Column {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 2
+
+                    Text {
+                        text: "Max fidelity"
+                        font.pixelSize: 15
+                        color: textColor
+                    }
+                    Text {
+                        text: root.maxFidelity ? "Best accuracy, about $0.60" : "Faster, about $0.30"
+                        font.pixelSize: 11
+                        color: secondaryText
+                    }
+                }
+
+                Switch {
+                    anchors.right: parent.right
+                    anchors.rightMargin: 8
+                    anchors.verticalCenter: parent.verticalCenter
+                    checked: root.maxFidelity
+                    onToggled: root.maxFidelity = checked
+                }
+            }
+
+            Item { width: 1; height: 16 }
+
+            Row {
+                spacing: 10
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                Rectangle {
+                    width: (rebuildDialog.width - 50) / 2
+                    height: 44
+                    radius: 10
+                    color: util.QML_ITEM_ALTERNATE_BG
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Cancel"
+                        font.pixelSize: 15
+                        color: textColor
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: rebuildDialog.close()
+                    }
+                }
+
+                Rectangle {
+                    width: (rebuildDialog.width - 50) / 2
+                    height: 44
+                    radius: 10
+                    color: accentColor
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Continue"
+                        font.pixelSize: 15
+                        color: "white"
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            personalApp.rebuildDiagram(root.maxFidelity ? 8 : 4)
+                            rebuildDialog.close()
+                        }
+                    }
                 }
             }
         }

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -1106,7 +1106,7 @@ Page {
     }
 
     // TEMPORARY: remove this cost-confirmation dialog once a customer pricing model is added to the app.
-    property bool maxFidelity: true
+    property bool maxFidelity: false
     Popup {
         id: rebuildDialog
         objectName: "rebuildDialog"
@@ -1149,7 +1149,7 @@ Page {
 
             Text {
                 width: rebuildDialog.width - 40
-                text: "This re-runs the AI several times to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about $0.60 each time. Please check with patrick@alaskafamilysystems.com before continuing."
+                text: "This re-runs the AI several times to reconstruct a more complete, better-connected diagram from your discussions. It costs Alaska Family Systems about " + (root.maxFidelity ? "$0.60" : "$0.30") + " each time. Please check with patrick@alaskafamilysystems.com before continuing."
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
                 color: secondaryText

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -1582,6 +1582,44 @@ def test_pollRebuild_error_emits_extractFailed(qApp):
     assert "Model overload" in failed.callArgs[0][0]
 
 
+def test_rebuild_watchdog_fails_when_progress_stalls(qApp):
+    """A crashed/killed worker never advances progress; the poller must fail
+    after REBUILD_STALL_MS instead of spinning on a dead task forever."""
+    from pkdiagram.personal.personalappcontroller import REBUILD_STALL_MS
+
+    controller = PersonalAppController()
+    base = 1000
+    controller._rebuildLastProgressMs = base
+    failed = util.Condition(controller.extractFailed)
+
+    assert controller._rebuildStalled(base + REBUILD_STALL_MS - 1) is False
+    assert failed.callCount == 0
+    assert controller._rebuildStalled(base + REBUILD_STALL_MS + 1) is True
+    assert failed.callCount == 1
+    assert "stopped responding" in failed.callArgs[0][0]
+
+
+def test_cancelRebuild_stops_polling_posts_cancel_and_emits(qApp):
+    """Cancel stops the poll loop, tells the server to abort, and emits
+    rebuildCancelled so the overlay dismisses without an error dialog."""
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    controller._rebuildTaskId = "task-abc"
+    cancelled = util.Condition(controller.rebuildCancelled)
+    server = MagicMock()
+    server.nonBlockingRequest.return_value = MagicMock()
+
+    with patch.object(controller.session, "server", return_value=server):
+        controller.cancelRebuild()
+
+    assert controller._rebuildCancelled is True
+    assert cancelled.callCount == 1
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert args[0] == "POST"
+    assert "/deep-reextract/task-abc/cancel" in args[1]
+
+
 def test_canRebuild_false_without_discussion(qApp):
     controller = PersonalAppController()
     controller._currentDiscussion = None

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -1403,6 +1403,103 @@ def test_rejectCommittedDelete_preserves_entity(
     assert personalApp._undoStack.canUndo()
 
 
+# --- FD-338: parents-only edit rows are the server-applied channel ---
+
+
+def test_isParentsEdit_slot(personalApp: PersonalAppController):
+    assert personalApp.isParentsEdit({"id": 10, "parents": 30}) is True
+    assert (
+        personalApp.isParentsEdit({"id": 10, "name": "Alicia", "parents": 30}) is False
+    )
+    assert personalApp.isParentsEdit({"id": -1, "name": "Mom"}) is False
+
+
+def _diagram_with_pdp(test_user, pdp):
+    return Diagram(
+        id=1,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(
+            asdict(DiagramData(people=[{"id": 10, "name": "Alice"}], pdp=pdp))
+        ),
+    )
+
+
+def test_acceptAll_excludes_parents_only_row(
+    test_user, personalApp: PersonalAppController
+):
+    """Parents-only rows are not user-reviewable: not applied client-side, not
+    echoed in item_ids, and don't block full_accept. The row stays staged for
+    the server to apply on full accept."""
+    personalApp._diagram = _diagram_with_pdp(
+        test_user,
+        PDP(people=[Person(id=-1, name="Mom"), Person(id=10, parents=30)]),
+    )
+    with (
+        patch.object(personalApp, "_addCommittedItemsToScene"),
+        patch.object(personalApp.clusterModel, "detect"),
+        patch.object(personalApp, "_postCommitPdp") as post,
+    ):
+        personalApp.acceptAllPDPItems()
+
+    post.assert_called_once_with([-1], True)
+    diagramData = personalApp._diagram.getDiagramData()
+    assert [p.id for p in diagramData.pdp.people] == [10]
+    alice = next(p for p in diagramData.people if p["id"] == 10)
+    assert alice.get("parents") is None  # application is the server's job
+
+
+def test_acceptPDPItem_last_negative_full_accept_with_parents_row_staged(
+    test_user, personalApp: PersonalAppController
+):
+    personalApp._diagram = _diagram_with_pdp(
+        test_user,
+        PDP(people=[Person(id=-1, name="Mom"), Person(id=10, parents=30)]),
+    )
+    with (
+        patch.object(personalApp, "_addCommittedItemsToScene"),
+        patch.object(personalApp, "_postCommitPdp") as post,
+    ):
+        personalApp._doAcceptPDPItem(-1)
+
+    post.assert_called_once_with([-1], True)
+
+
+def test_acceptAll_name_edit_row_still_echoed(
+    test_user, personalApp: PersonalAppController
+):
+    """FD-333 Update-card contract unchanged: rows with name/gender are
+    applied client-side and echoed in item_ids."""
+    personalApp._diagram = _diagram_with_pdp(
+        test_user, PDP(people=[Person(id=10, name="Alicia")])
+    )
+    with (
+        patch.object(personalApp, "_addCommittedItemsToScene"),
+        patch.object(personalApp.clusterModel, "detect"),
+        patch.object(personalApp, "_postCommitPdp") as post,
+    ):
+        personalApp.acceptAllPDPItems()
+
+    post.assert_called_once_with([10], True)
+    diagramData = personalApp._diagram.getDiagramData()
+    assert next(p for p in diagramData.people if p["id"] == 10)["name"] == "Alicia"
+
+
+def test_acceptCommittedEdit_posts_full_accept_when_last_card(
+    test_user, personalApp: PersonalAppController
+):
+    """Per-item review ending on an Update card must still advance the cursor:
+    accepting it POSTs commit-pdp with full_accept True."""
+    personalApp._diagram = _diagram_with_pdp(
+        test_user, PDP(people=[Person(id=10, name="Alicia")])
+    )
+    with patch.object(personalApp, "_postCommitPdp") as post:
+        assert personalApp.acceptCommittedEdit(10) is True
+
+    post.assert_called_once_with([10], True)
+
+
 # --- FD-338: rebuildDiagram ---
 
 
@@ -1433,7 +1530,7 @@ def test_rebuildDiagram_posts_correct_k(qApp):
     assert kwargs["data"] == {"k": 8}
 
 
-def test_rebuildDiagram_posts_k4(qApp):
+def test_rebuildDiagram_posts_k1(qApp):
     controller = PersonalAppController()
     controller._diagram = _rebuild_diagram()
     controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
@@ -1441,10 +1538,10 @@ def test_rebuildDiagram_posts_k4(qApp):
     server.nonBlockingRequest.return_value = MagicMock()
 
     with patch.object(controller.session, "server", return_value=server):
-        controller.rebuildDiagram(4)
+        controller.rebuildDiagram(1)
 
     args, kwargs = server.nonBlockingRequest.call_args
-    assert kwargs["data"] == {"k": 4}
+    assert kwargs["data"] == {"k": 1}
 
 
 def test_rebuildDiagram_emits_extractStarted_and_rebuildProgress(qApp):

--- a/pkdiagram/tests/personal/test_personalappcontroller.py
+++ b/pkdiagram/tests/personal/test_personalappcontroller.py
@@ -1285,7 +1285,9 @@ def test_acceptAll_empty_pdp_clears_extract_button(
 from btcopilot.schema import Event, EventKind
 
 
-def test_acceptCommittedEdit_applies_and_undoes(test_user, personalApp: PersonalAppController):
+def test_acceptCommittedEdit_applies_and_undoes(
+    test_user, personalApp: PersonalAppController
+):
     initial_diagram_data = DiagramData(
         people=[{"id": 10, "name": "Alice"}],
         pdp=PDP(people=[Person(id=10, name="Alicia")]),
@@ -1311,7 +1313,9 @@ def test_acceptCommittedEdit_applies_and_undoes(test_user, personalApp: Personal
     assert len(diagramData.pdp.people) == 1
 
 
-def test_rejectCommittedEdit_discards_and_undoes(test_user, personalApp: PersonalAppController):
+def test_rejectCommittedEdit_discards_and_undoes(
+    test_user, personalApp: PersonalAppController
+):
     initial_diagram_data = DiagramData(
         people=[{"id": 10, "name": "Alice"}],
         pdp=PDP(people=[Person(id=10, name="Alicia")]),
@@ -1336,10 +1340,20 @@ def test_rejectCommittedEdit_discards_and_undoes(test_user, personalApp: Persona
     assert len(diagramData.pdp.people) == 1
 
 
-def test_acceptCommittedDelete_cascade_and_undoes(test_user, personalApp: PersonalAppController):
+def test_acceptCommittedDelete_cascade_and_undoes(
+    test_user, personalApp: PersonalAppController
+):
     initial_diagram_data = DiagramData(
         people=[{"id": 10, "name": "Alice"}, {"id": 11, "name": "Bob"}],
-        events=[{"id": 20, "kind": "shift", "person": 10, "description": "x", "dateTime": "2000-01-01"}],
+        events=[
+            {
+                "id": 20,
+                "kind": "shift",
+                "person": 10,
+                "description": "x",
+                "dateTime": "2000-01-01",
+            }
+        ],
         pair_bonds=[{"id": 30, "person_a": 10, "person_b": 11}],
         pdp=PDP(delete=[10]),
     )
@@ -1366,7 +1380,9 @@ def test_acceptCommittedDelete_cascade_and_undoes(test_user, personalApp: Person
     assert len(diagramData.pdp.delete) == 1
 
 
-def test_rejectCommittedDelete_preserves_entity(test_user, personalApp: PersonalAppController):
+def test_rejectCommittedDelete_preserves_entity(
+    test_user, personalApp: PersonalAppController
+):
     initial_diagram_data = DiagramData(
         people=[{"id": 10, "name": "Alice"}],
         pdp=PDP(delete=[10]),
@@ -1385,3 +1401,208 @@ def test_rejectCommittedDelete_preserves_entity(test_user, personalApp: Personal
     assert any(p["id"] == 10 for p in diagramData.people)
     assert diagramData.pdp.delete == []
     assert personalApp._undoStack.canUndo()
+
+
+# --- FD-338: rebuildDiagram ---
+
+
+def _rebuild_diagram(user_id=1):
+    return Diagram(
+        id=42,
+        user_id=user_id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(DiagramData(people=[{"id": 1, "name": "Alice"}]))),
+    )
+
+
+def test_rebuildDiagram_posts_correct_k(qApp):
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    server = MagicMock()
+    server.nonBlockingRequest.return_value = MagicMock()
+
+    with patch.object(controller.session, "server", return_value=server):
+        controller.rebuildDiagram(8)
+
+    server.nonBlockingRequest.assert_called_once()
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert args[0] == "POST"
+    assert args[1] == "/personal/discussions/7/deep-reextract"
+    assert kwargs["data"] == {"k": 8}
+
+
+def test_rebuildDiagram_posts_k4(qApp):
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    server = MagicMock()
+    server.nonBlockingRequest.return_value = MagicMock()
+
+    with patch.object(controller.session, "server", return_value=server):
+        controller.rebuildDiagram(4)
+
+    args, kwargs = server.nonBlockingRequest.call_args
+    assert kwargs["data"] == {"k": 4}
+
+
+def test_rebuildDiagram_emits_extractStarted_and_rebuildProgress(qApp):
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    started = util.Condition(controller.extractStarted)
+    progress = util.Condition(controller.rebuildProgress)
+
+    server = MagicMock()
+    server.nonBlockingRequest.return_value = MagicMock()
+
+    with patch.object(controller.session, "server", return_value=server):
+        controller.rebuildDiagram(8)
+
+    assert started.callCount == 1
+    assert progress.callCount >= 1
+    assert progress.callArgs[0][0] == 0  # first percent is 0
+
+
+def test_rebuildDiagram_no_discussion_emits_extractFailed(qApp):
+    controller = PersonalAppController()
+    controller._currentDiscussion = None
+    failed = util.Condition(controller.extractFailed)
+    controller.rebuildDiagram(8)
+    assert failed.callCount == 1
+
+
+def test_rebuildDiagram_no_diagram_emits_extractFailed(qApp):
+    controller = PersonalAppController()
+    controller._diagram = None
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    failed = util.Condition(controller.extractFailed)
+    controller.rebuildDiagram(8)
+    assert failed.callCount == 1
+
+
+def _fake_poll_sequence(responses):
+    """Return a nonBlockingRequest side_effect that serves responses in order,
+    calling success with each dict in turn."""
+    call_index = {"i": 0}
+
+    def side_effect(verb, path, success=None, error=None, **kwargs):
+        i = call_index["i"]
+        call_index["i"] += 1
+        if i < len(responses):
+            success(responses[i])
+        return MagicMock()
+
+    return side_effect
+
+
+def test_pollRebuild_progress_to_complete_applies_pdp_and_emits_signals(qApp):
+    """_pollRebuild: progress→complete applies the PDP and emits pdpChanged+extractCompleted.
+    We call _pollRebuild directly to avoid the 1-second QTimer between polls."""
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+
+    rebuilt_pdp = PDP(people=[Person(id=-1, name="Bob")])
+    complete_response = {
+        "status": "complete",
+        "people_count": 1,
+        "events_count": 0,
+        "pair_bonds_count": 0,
+        "pdp": asdict(rebuilt_pdp),
+        "lcc_pct": 100,
+        "k": 6,
+    }
+    progress_response = {
+        "status": "progress",
+        "current": 3,
+        "total": 6,
+        "label": "Rebuild 3 of 6",
+    }
+
+    pdpChanged = util.Condition(controller.pdpChanged)
+    completed = util.Condition(controller.extractCompleted)
+    rebuildProgress = util.Condition(controller.rebuildProgress)
+
+    # Two poll calls: first returns progress, second returns complete.
+    call_index = {"i": 0}
+    responses = [progress_response, complete_response]
+
+    def fake_nbr(verb, path, success=None, error=None, **kwargs):
+        i = call_index["i"]
+        call_index["i"] += 1
+        if i < len(responses):
+            success(responses[i])
+        return MagicMock()
+
+    server = MagicMock()
+    server.nonBlockingRequest.side_effect = fake_nbr
+
+    with (
+        patch.object(controller.session, "server", return_value=server),
+        patch.object(controller._diagram, "save", return_value=True),
+    ):
+        # Call _pollRebuild directly; the progress handler schedules a QTimer for
+        # the second poll. Run event loop inside the mock context to fire the timer.
+        controller._pollRebuild(7, "task-abc")
+        # First poll fires synchronously: emits rebuildProgress(50, ...) and
+        # schedules QTimer(1000) for second poll.
+        assert rebuildProgress.callCount >= 1
+        progress_args = rebuildProgress.callArgs[0]
+        assert progress_args[0] == 50
+        assert progress_args[1] == "Rebuild 3 of 6"
+
+        # Wait for the 1-second timer to fire and complete the second poll.
+        assert completed.wait(maxMS=2000)
+        summary = completed.callArgs[0][0]
+        assert summary["people"] == 1
+        assert summary["events"] == 0
+        assert summary["pairBonds"] == 0
+
+        assert pdpChanged.callCount >= 1
+
+
+def test_pollRebuild_error_emits_extractFailed(qApp):
+    """_pollRebuild: error status emits extractFailed with the error message."""
+    controller = PersonalAppController()
+    failed = util.Condition(controller.extractFailed)
+
+    def fake_nbr(verb, path, success=None, error=None, **kwargs):
+        success({"status": "error", "error": "Model overload"})
+        return MagicMock()
+
+    server = MagicMock()
+    server.nonBlockingRequest.side_effect = fake_nbr
+
+    with patch.object(controller.session, "server", return_value=server):
+        controller._pollRebuild(7, "task-xyz")
+
+    assert failed.callCount == 1
+    assert "Model overload" in failed.callArgs[0][0]
+
+
+def test_canRebuild_false_without_discussion(qApp):
+    controller = PersonalAppController()
+    controller._currentDiscussion = None
+    assert controller.canRebuild is False
+
+
+def test_canRebuild_false_without_people(qApp):
+    controller = PersonalAppController()
+    controller._diagram = Diagram(
+        id=42,
+        user_id=1,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(DiagramData())),
+    )
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    assert controller.canRebuild is False
+
+
+def test_canRebuild_true_with_people(qApp):
+    controller = PersonalAppController()
+    controller._diagram = _rebuild_diagram()
+    controller._currentDiscussion = Discussion(id=7, user_id=1, diagram_id=42)
+    assert controller.canRebuild is True


### PR DESCRIPTION
## FD-338 — frontend (Personal app)

UI for **deep re-extraction**. Backend: patrickkidd/btcopilot#125.

### What it adds
- **Rebuild button** in `PersonalContainer` (28px circle, left of Extract; visible on the Discuss tab when `canRebuild`).
- **Cost-confirm modal** (mirrors `clearDataDialog`) carrying a **"Max fidelity"** toggle — default on = K=8 (~$0.60), off = K=4 (~$0.30). Tagged in-code as **TEMPORARY: remove once a customer pricing model exists**. Copy says it costs Alaska Family Systems ~$0.60/run and to check with patrick@alaskafamilysystems.com first.
- **Determinate progress** variant of the shared `LoadingOverlay` (back-compatible: `progress = -1` keeps the legacy indeterminate spinner for `importOverlay`).
- Controller `rebuildDiagram(k)` → `POST …/deep-reextract`, then polls `…/deep-reextract-status/<task_id>`; emits `rebuildProgress`; on completion deserializes the PDP and reuses the **existing PDPSheet** review/accept flow (no change to accept/reject).

Spec: `doc/ui-specs/rebuild-diagram.md`; prototype: `doc/ui-prototyping/5-Rebuild-Diagram/`.

### Verification
- **83/83** Personal-app tests (10 new: `rebuildDiagram` posts correct k, polling progress→complete applies the PDP and emits signals, progress→error path, `canRebuild`).
- qmllint clean on the changed QML.

### Known gap
- App-interactive E2E (button → modal → live worker → review sheet) not run here — the worktree app isn't built in this env and there's no Redis/worker to complete a rebuild. To be tested in a built environment with a worker. Controller logic underneath is unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)