### PR TITLE
FD-321: Personal app user profile wizard + Settings editor

### DIFF
--- a/doc/ui-specs/prototypes/1-user-details-A-single.qml
+++ b/doc/ui-specs/prototypes/1-user-details-A-single.qml
@@ -1,0 +1,189 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Variant A — single-screen wizard. One scroll, name + birth date together.
+// Root is sized by QQuickView (SizeRootObjectToView); do not anchor to parent.
+Rectangle {
+    id: root
+    width: 390
+    height: 844
+    color: util.QML_WINDOW_BG
+
+    property color itemBg: util.QML_ITEM_BG
+    property color textColor: util.QML_TEXT_COLOR
+    property color secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color accent: util.QML_SELECTION_COLOR
+    property color danger: "#ff453a"
+
+    // --- model state ---
+    property string firstName: ""
+    property string lastName: ""
+    property string birthMonth: ""
+    property string birthDay: ""
+    property string birthYear: ""
+
+    function dateEmpty() { return birthMonth === "" && birthDay === "" && birthYear === "" }
+    function dateValid() {
+        if (dateEmpty()) return true
+        var m = parseInt(birthMonth), d = parseInt(birthDay), y = parseInt(birthYear)
+        if (isNaN(m) || isNaN(d) || isNaN(y)) return false
+        if (m < 1 || m > 12) return false
+        if (d < 1 || d > 31) return false
+        if (birthYear.length !== 4 || y < 1900 || y > 2025) return false
+        return true
+    }
+    property bool nameValid: firstName.trim() !== ""
+    property bool canContinue: nameValid && dateValid()
+
+    // ---------- field component ----------
+    Component {
+        id: fieldCell
+        Item {
+            property alias text: input.text
+            property string placeholder: ""
+            property bool showError: false
+            property int maxLen: 0
+            property var validator: null
+            implicitHeight: 50
+            Text {
+                visible: input.text === ""
+                anchors.left: parent.left; anchors.leftMargin: 14
+                anchors.verticalCenter: parent.verticalCenter
+                text: parent.placeholder
+                color: root.secondaryText
+                font.pixelSize: 16
+            }
+            TextInput {
+                id: input
+                anchors.fill: parent
+                anchors.leftMargin: 14; anchors.rightMargin: 14
+                verticalAlignment: TextInput.AlignVCenter
+                color: parent.showError ? root.danger : root.textColor
+                font.pixelSize: 16
+                clip: true
+                maximumLength: parent.maxLen > 0 ? parent.maxLen : 32767
+                validator: parent.validator
+            }
+        }
+    }
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: col.height + 40
+        clip: true
+
+        Column {
+            id: col
+            x: 20
+            width: parent.width - 40
+            topPadding: 80
+            spacing: 18
+
+            Text {
+                text: "Welcome"
+                color: root.textColor
+                font.pixelSize: 30
+                font.bold: true
+            }
+            Text {
+                width: col.width - 40
+                text: "Tell us who you are so your diagram and the assistant know which person is you."
+                color: root.secondaryText
+                font.pixelSize: 15
+                wrapMode: Text.WordWrap
+                lineHeight: 1.3
+            }
+
+            // YOUR NAME
+            Text { text: "YOUR NAME"; color: root.secondaryText; font.pixelSize: 12; font.bold: true; leftPadding: 4; topPadding: 12 }
+            Rectangle {
+                width: col.width; height: 101; radius: 12
+                color: root.itemBg; border.width: 1
+                border.color: (!root.nameValid && root.firstName !== "") ? root.danger : root.borderColor
+                Column {
+                    anchors.fill: parent
+                    Loader {
+                        id: firstLoader
+                        width: parent.width; height: 50
+                        sourceComponent: fieldCell
+                        onLoaded: { item.placeholder = "First name"; item.text = root.firstName }
+                        Connections { target: firstLoader.item; function onTextChanged() { root.firstName = firstLoader.item.text } }
+                    }
+                    Rectangle { x: 14; width: parent.width - 14; height: 1; color: root.borderColor }
+                    Loader {
+                        id: lastLoader
+                        width: parent.width; height: 50
+                        sourceComponent: fieldCell
+                        onLoaded: { item.placeholder = "Last name"; item.text = root.lastName }
+                        Connections { target: lastLoader.item; function onTextChanged() { root.lastName = lastLoader.item.text } }
+                    }
+                }
+            }
+            Text {
+                visible: !root.nameValid && root.firstName !== ""
+                text: "First name is required."
+                color: root.danger; font.pixelSize: 12; leftPadding: 4
+            }
+
+            // DATE OF BIRTH
+            Text { text: "DATE OF BIRTH"; color: root.secondaryText; font.pixelSize: 12; font.bold: true; leftPadding: 4; topPadding: 12 }
+            Rectangle {
+                width: col.width; height: 50; radius: 12
+                color: root.itemBg; border.width: 1
+                border.color: !root.dateValid() ? root.danger : root.borderColor
+                Row {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left; anchors.leftMargin: 14
+                    spacing: 6
+                    Loader { id: mLoader; width: 38; height: 40; sourceComponent: fieldCell
+                        onLoaded: { item.placeholder = "MM"; item.maxLen = 2 }
+                        Connections { target: mLoader.item; function onTextChanged() { root.birthMonth = mLoader.item.text } } }
+                    Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                    Loader { id: dLoader; width: 38; height: 40; sourceComponent: fieldCell
+                        onLoaded: { item.placeholder = "DD"; item.maxLen = 2 }
+                        Connections { target: dLoader.item; function onTextChanged() { root.birthDay = dLoader.item.text } } }
+                    Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                    Loader { id: yLoader; width: 64; height: 40; sourceComponent: fieldCell
+                        onLoaded: { item.placeholder = "YYYY"; item.maxLen = 4 }
+                        Connections { target: yLoader.item; function onTextChanged() { root.birthYear = yLoader.item.text } } }
+                }
+            }
+            Text {
+                visible: !root.dateValid()
+                text: "Enter a valid date (MM / DD / YYYY)."
+                color: root.danger; font.pixelSize: 12; leftPadding: 4
+            }
+            Text {
+                visible: root.dateValid()
+                text: "Optional — helps the assistant anchor ages and timelines."
+                color: root.secondaryText; font.pixelSize: 12; leftPadding: 4
+            }
+        }
+    }
+
+    // ---------- bottom action bar ----------
+    Rectangle {
+        anchors.bottom: parent.bottom; width: parent.width; height: 120
+        color: util.QML_WINDOW_BG
+        Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: root.borderColor }
+
+        Rectangle {
+            id: primaryBtn
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: parent.top; anchors.topMargin: 16
+            width: parent.width - 40; height: 50; radius: 14
+            color: root.canContinue ? root.accent : root.borderColor
+            opacity: root.canContinue ? 1.0 : 0.5
+            Text { anchors.centerIn: parent; text: "Get Started"; color: "white"; font.pixelSize: 17; font.bold: true }
+            MouseArea { anchors.fill: parent; enabled: root.canContinue
+                onClicked: console.log("SAVE name=" + root.firstName + " " + root.lastName + " dob=" + root.birthMonth + "/" + root.birthDay + "/" + root.birthYear) }
+        }
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: primaryBtn.bottom; anchors.topMargin: 14
+            text: "Skip for now"; color: root.accent; font.pixelSize: 15
+            MouseArea { anchors.fill: parent; onClicked: console.log("SKIP") }
+        }
+    }
+}

--- a/doc/ui-specs/prototypes/1-user-details-B-paged.qml
+++ b/doc/ui-specs/prototypes/1-user-details-B-paged.qml
@@ -1,0 +1,203 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Variant B — multi-step paged wizard. Welcome -> Name -> Birth date -> Done.
+Rectangle {
+    id: root
+    width: 390
+    height: 844
+    color: util.QML_WINDOW_BG
+
+    property color itemBg: util.QML_ITEM_BG
+    property color textColor: util.QML_TEXT_COLOR
+    property color secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color accent: util.QML_SELECTION_COLOR
+    property color danger: "#ff453a"
+
+    property string firstName: ""
+    property string lastName: ""
+    property string birthMonth: ""
+    property string birthDay: ""
+    property string birthYear: ""
+
+    function dateEmpty() { return birthMonth === "" && birthDay === "" && birthYear === "" }
+    function dateValid() {
+        if (dateEmpty()) return true
+        var m = parseInt(birthMonth), d = parseInt(birthDay), y = parseInt(birthYear)
+        if (isNaN(m) || isNaN(d) || isNaN(y)) return false
+        if (m < 1 || m > 12) return false
+        if (d < 1 || d > 31) return false
+        if (birthYear.length !== 4 || y < 1900 || y > 2025) return false
+        return true
+    }
+    property bool nameValid: firstName.trim() !== ""
+    function canAdvance() {
+        if (swipe.currentIndex === 1) return nameValid
+        if (swipe.currentIndex === 2) return dateValid()
+        return true
+    }
+
+    Component {
+        id: fieldCell
+        Item {
+            property alias text: input.text
+            property string placeholder: ""
+            property int maxLen: 0
+            implicitHeight: 50
+            Text {
+                visible: input.text === ""
+                anchors.left: parent.left; anchors.leftMargin: 14
+                anchors.verticalCenter: parent.verticalCenter
+                text: parent.placeholder; color: root.secondaryText; font.pixelSize: 16
+            }
+            TextInput {
+                id: input
+                anchors.fill: parent; anchors.leftMargin: 14; anchors.rightMargin: 14
+                verticalAlignment: TextInput.AlignVCenter
+                color: root.textColor; font.pixelSize: 16; clip: true
+                maximumLength: parent.maxLen > 0 ? parent.maxLen : 32767
+            }
+        }
+    }
+
+    // Skip top-right
+    Text {
+        anchors.top: parent.top; anchors.topMargin: 40
+        anchors.right: parent.right; anchors.rightMargin: 20
+        text: "Skip"; color: root.accent; font.pixelSize: 15; z: 50
+        MouseArea { anchors.fill: parent; onClicked: console.log("SKIP") }
+    }
+
+    SwipeView {
+        id: swipe
+        anchors.top: parent.top; anchors.topMargin: 90
+        anchors.left: parent.left; anchors.right: parent.right
+        anchors.bottom: footer.top
+        interactive: false
+        clip: true
+
+        // Page 0 — Welcome
+        Item {
+            Column {
+                anchors.centerIn: parent
+                width: parent.width - 60
+                spacing: 18
+                Text { text: "👋"; font.pixelSize: 56; anchors.horizontalCenter: parent.horizontalCenter }
+                Text { text: "Welcome to\nFamily Diagram"; color: root.textColor; font.pixelSize: 28; font.bold: true
+                    horizontalAlignment: Text.AlignHCenter; width: parent.width; wrapMode: Text.WordWrap }
+                Text { text: "A couple of quick details so your diagram knows which person is you."
+                    color: root.secondaryText; font.pixelSize: 16; horizontalAlignment: Text.AlignHCenter
+                    width: parent.width; wrapMode: Text.WordWrap; lineHeight: 1.3 }
+            }
+        }
+
+        // Page 1 — Name
+        Item {
+            Column {
+                x: 30; width: parent.width - 60; topPadding: 20; spacing: 16
+                Text { text: "What's your name?"; color: root.textColor; font.pixelSize: 24; font.bold: true }
+                Text { text: "This labels your own node on the diagram."
+                    color: root.secondaryText; font.pixelSize: 15; width: parent.width; wrapMode: Text.WordWrap }
+                Rectangle {
+                    width: parent.width; height: 101; radius: 12; color: root.itemBg
+                    border.width: 1; border.color: root.borderColor
+                    Column {
+                        anchors.fill: parent
+                        Loader { id: fL; width: parent.width; height: 50; sourceComponent: fieldCell
+                            onLoaded: { item.placeholder = "First name"; item.text = root.firstName }
+                            Connections { target: fL.item; function onTextChanged() { root.firstName = fL.item.text } } }
+                        Rectangle { x: 14; width: parent.width - 14; height: 1; color: root.borderColor }
+                        Loader { id: lL; width: parent.width; height: 50; sourceComponent: fieldCell
+                            onLoaded: { item.placeholder = "Last name"; item.text = root.lastName }
+                            Connections { target: lL.item; function onTextChanged() { root.lastName = lL.item.text } } }
+                    }
+                }
+                Text { visible: !root.nameValid && root.firstName !== ""
+                    text: "First name is required."; color: root.danger; font.pixelSize: 12 }
+            }
+        }
+
+        // Page 2 — Birth date
+        Item {
+            Column {
+                x: 30; width: parent.width - 60; topPadding: 20; spacing: 16
+                Text { text: "When were you born?"; color: root.textColor; font.pixelSize: 24; font.bold: true }
+                Text { text: "Optional. Helps anchor ages and dates the assistant hears."
+                    color: root.secondaryText; font.pixelSize: 15; width: parent.width; wrapMode: Text.WordWrap }
+                Rectangle {
+                    width: parent.width; height: 50; radius: 12; color: root.itemBg
+                    border.width: 1; border.color: !root.dateValid() ? root.danger : root.borderColor
+                    Row {
+                        anchors.verticalCenter: parent.verticalCenter; anchors.left: parent.left; anchors.leftMargin: 14; spacing: 6
+                        Loader { id: mL; width: 40; height: 40; sourceComponent: fieldCell
+                            onLoaded: { item.placeholder = "MM"; item.maxLen = 2 }
+                            Connections { target: mL.item; function onTextChanged() { root.birthMonth = mL.item.text } } }
+                        Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                        Loader { id: dL; width: 40; height: 40; sourceComponent: fieldCell
+                            onLoaded: { item.placeholder = "DD"; item.maxLen = 2 }
+                            Connections { target: dL.item; function onTextChanged() { root.birthDay = dL.item.text } } }
+                        Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                        Loader { id: yL; width: 66; height: 40; sourceComponent: fieldCell
+                            onLoaded: { item.placeholder = "YYYY"; item.maxLen = 4 }
+                            Connections { target: yL.item; function onTextChanged() { root.birthYear = yL.item.text } } }
+                    }
+                }
+                Text { visible: !root.dateValid(); text: "Enter a valid date (MM / DD / YYYY)."
+                    color: root.danger; font.pixelSize: 12 }
+            }
+        }
+
+        // Page 3 — Done
+        Item {
+            Column {
+                anchors.centerIn: parent; width: parent.width - 60; spacing: 16
+                Text { text: "✓"; font.pixelSize: 56; color: root.accent; anchors.horizontalCenter: parent.horizontalCenter }
+                Text { text: root.firstName !== "" ? ("You're all set, " + root.firstName + ".") : "You're all set."
+                    color: root.textColor; font.pixelSize: 24; font.bold: true
+                    horizontalAlignment: Text.AlignHCenter; width: parent.width; wrapMode: Text.WordWrap }
+                Text { text: "You can change these any time in Settings."
+                    color: root.secondaryText; font.pixelSize: 15; horizontalAlignment: Text.AlignHCenter
+                    width: parent.width; wrapMode: Text.WordWrap }
+            }
+        }
+    }
+
+    PageIndicator {
+        anchors.bottom: footer.top; anchors.bottomMargin: 8
+        anchors.horizontalCenter: parent.horizontalCenter
+        count: swipe.count; currentIndex: swipe.currentIndex
+    }
+
+    // Footer Back / Next
+    Rectangle {
+        id: footer
+        anchors.bottom: parent.bottom; width: parent.width; height: 96
+        color: util.QML_WINDOW_BG
+        Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: root.borderColor }
+
+        Text {
+            visible: swipe.currentIndex > 0
+            anchors.left: parent.left; anchors.leftMargin: 24
+            anchors.top: parent.top; anchors.topMargin: 28
+            text: "Back"; color: root.accent; font.pixelSize: 17
+            MouseArea { anchors.fill: parent; onClicked: swipe.currentIndex-- }
+        }
+        Rectangle {
+            anchors.right: parent.right; anchors.rightMargin: 20
+            anchors.top: parent.top; anchors.topMargin: 16
+            width: 120; height: 50; radius: 14
+            color: root.canAdvance() ? root.accent : root.borderColor
+            opacity: root.canAdvance() ? 1.0 : 0.5
+            Text { anchors.centerIn: parent
+                text: swipe.currentIndex === swipe.count - 1 ? "Finish" : "Next"
+                color: "white"; font.pixelSize: 17; font.bold: true }
+            MouseArea { anchors.fill: parent; enabled: root.canAdvance()
+                onClicked: {
+                    if (swipe.currentIndex === swipe.count - 1) console.log("SAVE+FINISH name=" + root.firstName)
+                    else swipe.currentIndex++
+                }
+            }
+        }
+    }
+}

--- a/doc/ui-specs/prototypes/FINAL-user-details.qml
+++ b/doc/ui-specs/prototypes/FINAL-user-details.qml
@@ -1,0 +1,171 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// FINAL — FD-321 user-details, single-screen (variant A, chosen 2026-06-15).
+// One reusable UserDetailsForm drives BOTH surfaces:
+//   - first-launch wizard (this file shows wizardMode=true: title/subtitle + Get Started + Skip)
+//   - Settings profile editor (wizardMode=false: header back + Save, no Skip)
+// Real implementation maps:
+//   firstName/lastName -> primary Person node name/lastName
+//   birth date         -> a Birth EVENT on the primary node (not a scalar field)
+//   skip               -> AppConfig pref "personalProfilePrompted" so the wizard never nags
+//   fields             -> swap the inline cells for PK.TextField / PK.DatePicker in the app
+Rectangle {
+    id: root
+    width: 390
+    height: 844
+    color: util.QML_WINDOW_BG
+
+    property bool wizardMode: true   // demo: the wizard surface
+
+    property color itemBg: util.QML_ITEM_BG
+    property color textColor: util.QML_TEXT_COLOR
+    property color secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color accent: util.QML_SELECTION_COLOR
+    property color danger: "#ff453a"
+
+    // ---- shared form component (the reusable piece) ----
+    Component {
+        id: userDetailsForm
+        Flickable {
+            id: form
+            property string firstName: ""
+            property string lastName: ""
+            property string birthMonth: ""
+            property string birthDay: ""
+            property string birthYear: ""
+            function dateEmpty() { return birthMonth === "" && birthDay === "" && birthYear === "" }
+            function dateValid() {
+                if (dateEmpty()) return true
+                var m = parseInt(birthMonth), d = parseInt(birthDay), y = parseInt(birthYear)
+                if (isNaN(m) || isNaN(d) || isNaN(y)) return false
+                if (m < 1 || m > 12) return false
+                if (d < 1 || d > 31) return false
+                if (birthYear.length !== 4 || y < 1900 || y > 2025) return false
+                return true
+            }
+            property bool nameValid: firstName.trim() !== ""
+            property bool valid: nameValid && dateValid()
+
+            contentHeight: col.height + 40
+            clip: true
+
+            Component {
+                id: cell
+                Item {
+                    property alias text: ti.text
+                    property string placeholder: ""
+                    property int maxLen: 0
+                    implicitHeight: 50
+                    Text {
+                        visible: ti.text === ""
+                        anchors.left: parent.left; anchors.leftMargin: 14
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: parent.placeholder; color: root.secondaryText; font.pixelSize: 16
+                    }
+                    TextInput {
+                        id: ti
+                        anchors.fill: parent; anchors.leftMargin: 14; anchors.rightMargin: 14
+                        verticalAlignment: TextInput.AlignVCenter
+                        color: root.textColor; font.pixelSize: 16; clip: true
+                        maximumLength: parent.maxLen > 0 ? parent.maxLen : 32767
+                    }
+                }
+            }
+
+            Column {
+                id: col
+                x: 20; width: form.width - 40
+                topPadding: root.wizardMode ? 80 : 20
+                spacing: 18
+
+                Text {
+                    visible: root.wizardMode
+                    text: "Welcome"; color: root.textColor; font.pixelSize: 30; font.bold: true
+                }
+                Text {
+                    visible: root.wizardMode
+                    width: col.width - 40
+                    text: "Tell us who you are so your diagram and the assistant know which person is you."
+                    color: root.secondaryText; font.pixelSize: 15; wrapMode: Text.WordWrap; lineHeight: 1.3
+                }
+
+                Text { text: "YOUR NAME"; color: root.secondaryText; font.pixelSize: 12; font.bold: true; leftPadding: 4; topPadding: root.wizardMode ? 12 : 0 }
+                Rectangle {
+                    width: col.width; height: 101; radius: 12; color: root.itemBg
+                    border.width: 1
+                    border.color: (!form.nameValid && form.firstName !== "") ? root.danger : root.borderColor
+                    Column {
+                        anchors.fill: parent
+                        Loader { id: fl; width: parent.width; height: 50; sourceComponent: cell
+                            onLoaded: item.placeholder = "First name"
+                            Connections { target: fl.item; function onTextChanged() { form.firstName = fl.item.text } } }
+                        Rectangle { x: 14; width: parent.width - 14; height: 1; color: root.borderColor }
+                        Loader { id: ll; width: parent.width; height: 50; sourceComponent: cell
+                            onLoaded: item.placeholder = "Last name"
+                            Connections { target: ll.item; function onTextChanged() { form.lastName = ll.item.text } } }
+                    }
+                }
+                Text { visible: !form.nameValid && form.firstName !== ""
+                    text: "First name is required."; color: root.danger; font.pixelSize: 12; leftPadding: 4 }
+
+                Text { text: "DATE OF BIRTH"; color: root.secondaryText; font.pixelSize: 12; font.bold: true; leftPadding: 4; topPadding: 12 }
+                Rectangle {
+                    width: col.width; height: 50; radius: 12; color: root.itemBg
+                    border.width: 1; border.color: !form.dateValid() ? root.danger : root.borderColor
+                    Row {
+                        anchors.verticalCenter: parent.verticalCenter; anchors.left: parent.left; anchors.leftMargin: 14; spacing: 6
+                        Loader { id: ml; width: 38; height: 40; sourceComponent: cell
+                            onLoaded: { item.placeholder = "MM"; item.maxLen = 2 }
+                            Connections { target: ml.item; function onTextChanged() { form.birthMonth = ml.item.text } } }
+                        Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                        Loader { id: dl; width: 38; height: 40; sourceComponent: cell
+                            onLoaded: { item.placeholder = "DD"; item.maxLen = 2 }
+                            Connections { target: dl.item; function onTextChanged() { form.birthDay = dl.item.text } } }
+                        Text { text: "/"; color: root.secondaryText; font.pixelSize: 16; anchors.verticalCenter: parent.verticalCenter }
+                        Loader { id: yl; width: 64; height: 40; sourceComponent: cell
+                            onLoaded: { item.placeholder = "YYYY"; item.maxLen = 4 }
+                            Connections { target: yl.item; function onTextChanged() { form.birthYear = yl.item.text } } }
+                    }
+                }
+                Text { visible: !form.dateValid()
+                    text: "Enter a valid date (MM / DD / YYYY)."; color: root.danger; font.pixelSize: 12; leftPadding: 4 }
+                Text { visible: form.dateValid()
+                    text: "Optional — helps the assistant anchor ages and timelines."
+                    color: root.secondaryText; font.pixelSize: 12; leftPadding: 4 }
+            }
+        }
+    }
+
+    Loader { id: formLoader; anchors.top: parent.top; anchors.bottom: bar.top; width: parent.width; sourceComponent: userDetailsForm }
+
+    // ---- action bar (wizard: Get Started + Skip / settings: Save) ----
+    Rectangle {
+        id: bar
+        anchors.bottom: parent.bottom; width: parent.width; height: root.wizardMode ? 120 : 86
+        color: util.QML_WINDOW_BG
+        Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: root.borderColor }
+
+        Rectangle {
+            id: primaryBtn
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: parent.top; anchors.topMargin: 16
+            width: parent.width - 40; height: 50; radius: 14
+            property bool ok: formLoader.item ? formLoader.item.valid : false
+            color: ok ? root.accent : root.borderColor
+            opacity: ok ? 1.0 : 0.5
+            Text { anchors.centerIn: parent; text: root.wizardMode ? "Get Started" : "Save"; color: "white"; font.pixelSize: 17; font.bold: true }
+            MouseArea { anchors.fill: parent; enabled: primaryBtn.ok
+                onClicked: console.log("SAVE", formLoader.item.firstName, formLoader.item.lastName,
+                                       formLoader.item.birthMonth + "/" + formLoader.item.birthDay + "/" + formLoader.item.birthYear) }
+        }
+        Text {
+            visible: root.wizardMode
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: primaryBtn.bottom; anchors.topMargin: 14
+            text: "Skip for now"; color: root.accent; font.pixelSize: 15
+            MouseArea { anchors.fill: parent; onClicked: console.log("SKIP -> set personalProfilePrompted=true") }
+        }
+    }
+}

--- a/doc/ui-specs/user-details.md
+++ b/doc/ui-specs/user-details.md
@@ -1,0 +1,67 @@
+# UI Spec: User Details (FD-321)
+
+**Decision (2026-06-15):** single-screen presentation (variant A). One reusable form drives both
+the first-launch wizard and the Settings profile editor. Reference demo:
+`doc/ui-specs/prototypes/FINAL-user-details.qml`.
+
+## Purpose
+
+Let a Personal-app user set their own name and birth date so (a) their own node on the diagram is
+named, and (b) extraction/rebuild context knows who the speaker is (kills the duplicate-proband
+class). Editable later in Settings.
+
+## Components
+
+### `UserDetailsForm.qml` (new, reusable — `Personal/`)
+The shared body. A `Flickable` + `Column` of grouped cards, matching `VoiceSettingsPage` styling
+(rounded `radius: 12` cards, `util.QML_ITEM_BG`, 1px `util.QML_ITEM_BORDER_COLOR` border, uppercase
+`QML_INACTIVE_TEXT_COLOR` section labels).
+
+- **YOUR NAME** card: two stacked fields — First name, Last name — separated by a hairline.
+  Use `PK.TextField`. First name required.
+- **DATE OF BIRTH** card: REUSE the `EventForm.qml` date idiom — a `PK.DatePickerButtons`
+  (`datePicker:` bound to a `PK.DatePicker`, `hideTime: true` since birth has no time) paired with
+  the `PK.DatePicker`. This gives a clickable/focusable editable date field; do NOT drop in a bare
+  `PK.DatePicker` (Patrick 2026-06-15: the bare picker was unfocusable/clunky and couldn't be clicked
+  into). Optional; the picker can only yield a real calendar date, so there is no invalid-date state.
+- **FOCUS / TAB ORDER (mandatory, Patrick 2026-06-15):** the form must honor tab-focus order —
+  First name → Last name → birth date field — via `KeyNavigation.tab`/`backtab` (chain the name
+  `PK.TextField`s to `dateButtons.firstTabItem`, mirroring EventForm). First name field takes initial
+  focus on open. Clicking any field must focus it.
+- **Validation (C3):** red border + red helper text when First name is blank-after-touch. The date
+  control cannot produce an invalid date, so C3 reduces to first-name-required. `valid = firstName.trim() != ""`.
+- Exposes: `firstName`, `lastName`, `birthDate` (or M/D/Y), `valid`.
+
+### Wizard surface (`wizardMode: true`)
+- Title "Welcome" + subtitle explaining why.
+- Bottom bar: **Get Started** (enabled only when `valid`) + **Skip for now** text button.
+- Mounted from `PersonalContainer` on first launch when the profile-prompt flag is unset AND the
+  current diagram's primary node has no name.
+
+### Settings surface (`wizardMode: false`)
+- Reuses the existing settings sub-page chrome (56px header, back chevron, centered title "Profile")
+  exactly like `VoiceSettingsPage`/`ModelSettingsPage`.
+- Bottom bar: **Save** (enabled when `valid`). No Skip.
+- Pre-populated from the primary node's current name + birth event.
+- Wire into `AccountDrawer` "ACCOUNT"/"Profile" entry (currently inert) and the Settings list.
+
+## States
+- **Empty / fresh:** wizard shown, all blank, Get Started disabled.
+- **Invalid:** red validation on the offending field, primary button disabled.
+- **Valid:** primary button enabled.
+- **Skipped:** flag set, wizard never reappears (C2); app fully usable.
+- **Pre-existing diagram (C6):** Settings opens with whatever the primary node already has (often
+  blank); editable; lands on primary node or deterministic fallback when none is marked primary.
+
+## Persistence (app → diagram → server)
+- Name → primary `Person.name` / `Person.lastName`.
+- Birth date → a **Birth event** on the primary node (NOT a scalar field) — Patrick, 2026-06-15.
+- Skip flag → `AppConfig` pref (e.g. `personalProfilePrompted`), local, survives relaunch.
+- Saved via the normal diagram save path; server diagram version advances; reload reflects it (C4/C5).
+- **Two-location field-sync (C7):** if any new `DiagramData`/`Person` field is added, update BOTH
+  `Scene.diagramData()` and `serverfilemanagermodel.applyChange()`/`setData()`. Birth-as-event avoids
+  a new scalar field, minimizing this surface.
+
+## Out of scope for this spec (handled in build, not UI)
+Extraction/rebuild context plumbing (C8–C11) and the chat-label rename (C13) are backend; this spec
+covers only the capture/edit UI.

--- a/pkdiagram/app/session.py
+++ b/pkdiagram/app/session.py
@@ -417,6 +417,27 @@ class Session(QObject, QObjectHelper):
         if self._data and self._data["session"]["token"]:
             self.login(token=self._data["session"]["token"])
 
+    @pyqtSlot(str, str, result=bool)
+    def updateName(self, first_name: str, last_name: str) -> bool:
+        """Write the user's account name to the server, then re-pull the session
+        so userDict (e.g. the account drawer) reflects it. Used by the Personal
+        app profile wizard to keep the account name in sync with the user's own
+        (free) diagram node; the caller scopes this to the free diagram only."""
+        if not (self._data and self._user):
+            return False
+        args = {
+            "session": self.token,
+            "first_name": first_name,
+            "last_name": last_name,
+        }
+        try:
+            self.server().blockingRequest("POST", f"/users/{self._user.id}", data=args)
+        except HTTPError:
+            log.error("Session.updateName failed", exc_info=True)
+            return False
+        self.update()
+        return True
+
     def error(self, etype, value, tb):
         import traceback
         from pkdiagram.app import DatadogLog

--- a/pkdiagram/app/session.py
+++ b/pkdiagram/app/session.py
@@ -435,7 +435,17 @@ class Session(QObject, QObjectHelper):
         except HTTPError:
             log.error("Session.updateName failed", exc_info=True)
             return False
-        self.update()
+        # Refresh the local user/userDict from the submitted values instead of
+        # re-pulling the whole session: a transient re-pull failure would call
+        # setData(None) and log the user out as a side effect of a name save.
+        self._user.first_name = first_name
+        self._user.last_name = last_name
+        self._userDict = dataclasses.asdict(self._user)
+        if self._data and self._data.get("session"):
+            self._data["session"]["user"]["first_name"] = first_name
+            self._data["session"]["user"]["last_name"] = last_name
+        self.refreshAllProperties()
+        self.changed.emit(self._activeFeatures, self._activeFeatures)
         return True
 
     def error(self, etype, value, tb):

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -443,9 +443,29 @@ class PersonalAppController(QObject):
             self.appConfig.write()
         self.userProfileChanged.emit()
 
+    def _isOwnDiagram(self) -> bool:
+        """True iff the active scene is the user's own (free) diagram, where the
+        primary node IS the account holder. The account name is linked only here.
+        A loaded client file (other owned/shared diagram, e.g. a clinician's
+        client) is NOT own; nothing-loaded is the fresh Personal default scene,
+        which IS the user's own (their free diagram is created on first save)."""
+        user = self.session.user if self.session else None
+        if user is None or user.free_diagram_id is None:
+            return False
+        if self._diagram is None:
+            return True
+        return self._diagram.id == user.free_diagram_id
+
     @pyqtProperty("QVariantMap", notify=userProfileChanged)
     def userProfile(self) -> dict:
         person = self._primaryPerson()
+        name = person.name() if person else None
+        if not name and self._isOwnDiagram():
+            # On the user's own diagram, pre-fill from the account name (set at
+            # signup) so the average self-user just confirms it and adds a birth date.
+            user = self.session.user
+            return {"firstName": user.first_name or "", "lastName": user.last_name or "",
+                    "birthYear": "", "birthMonth": "", "birthDay": ""}
         if not person:
             return {"firstName": "", "lastName": "", "birthYear": "", "birthMonth": "", "birthDay": ""}
         birth = person.birthDateTime()
@@ -498,6 +518,13 @@ class PersonalAppController(QObject):
             self.scene.removeItem(birthEvent)
 
         self.saveDiagram()
+
+        # On the user's OWN (free) diagram the primary node is the account holder,
+        # so keep the account name in sync. Never touch the account from a client
+        # file (other owned/shared diagrams), whose node is a different person.
+        if self._isOwnDiagram():
+            self.session.updateName(firstName.strip(), lastName.strip())
+
         self.markProfilePrompted()
         self.userProfileChanged.emit()
         return True

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -464,8 +464,14 @@ class PersonalAppController(QObject):
             # On the user's own diagram, pre-fill from the account name (set at
             # signup) so the average self-user just confirms it and adds a birth date.
             user = self.session.user
+            year, month, day = "", "", ""
+            if person:
+                birth = person.birthDateTime()
+                if birth and birth.isValid():
+                    d = birth.date()
+                    year, month, day = str(d.year()), str(d.month()), str(d.day())
             return {"firstName": user.first_name or "", "lastName": user.last_name or "",
-                    "birthYear": "", "birthMonth": "", "birthDay": ""}
+                    "birthYear": year, "birthMonth": month, "birthDay": day}
         if not person:
             return {"firstName": "", "lastName": "", "birthYear": "", "birthMonth": "", "birthDay": ""}
         birth = person.birthDateTime()

--- a/pkdiagram/personal/personalappcontroller.py
+++ b/pkdiagram/personal/personalappcontroller.py
@@ -360,6 +360,9 @@ class PersonalAppController(QObject):
             self.eventForm.setScene(scene)
         # Re-emit pdpChanged so committedPeople gets populated from the scene
         self.pdpChanged.emit()
+        # New scene -> the wizard gate and profile values depend on its primary
+        # node, so re-evaluate them (FD-321).
+        self.userProfileChanged.emit()
 
     def exec(self, mw):
         self.app.exec()
@@ -406,6 +409,98 @@ class PersonalAppController(QObject):
     @pyqtProperty(QObject, constant=True)
     def settings(self):
         return self._settings
+
+    # User profile (FD-321)
+
+    userProfileChanged = pyqtSignal()
+
+    def _primaryPerson(self) -> Person | None:
+        """The user's own node. The one marked primary, else a deterministic
+        fallback (lowest id) so a pre-existing diagram with no primary marked is
+        still editable. None only when the scene has no people."""
+        if not self.scene:
+            return None
+        primary = self.scene.query1(primary=True)
+        if primary is not None:
+            return primary
+        people = sorted(self.scene.people(), key=lambda p: p.id)
+        return people[0] if people else None
+
+    @pyqtProperty(bool, notify=userProfileChanged)
+    def shouldPromptProfile(self) -> bool:
+        """First-launch wizard gate: the prompt pref is unset AND the primary
+        node has no name. Either a completed save or an explicit skip sets the
+        pref, so the wizard never reappears."""
+        if self.appConfig.get("personalProfilePrompted"):
+            return False
+        person = self._primaryPerson()
+        return not (person and person.name())
+
+    @pyqtSlot()
+    def markProfilePrompted(self):
+        self.appConfig.set("personalProfilePrompted", True)
+        if self.appConfig.filePath:
+            self.appConfig.write()
+        self.userProfileChanged.emit()
+
+    @pyqtProperty("QVariantMap", notify=userProfileChanged)
+    def userProfile(self) -> dict:
+        person = self._primaryPerson()
+        if not person:
+            return {"firstName": "", "lastName": "", "birthYear": "", "birthMonth": "", "birthDay": ""}
+        birth = person.birthDateTime()
+        if birth and birth.isValid():
+            d = birth.date()
+            year, month, day = str(d.year()), str(d.month()), str(d.day())
+        else:
+            year, month, day = "", "", ""
+        return {
+            "firstName": person.name() or "",
+            "lastName": person.lastName() or "",
+            "birthYear": year,
+            "birthMonth": month,
+            "birthDay": day,
+        }
+
+    @pyqtSlot(str, str, int, int, int, result=bool)
+    def saveUserProfile(
+        self, firstName: str, lastName: str, year: int, month: int, day: int
+    ) -> bool:
+        """Land name on the primary Person and birth date as a Birth event on
+        it, then persist via the normal save path. A primary person is created
+        if the diagram has none. Returns False if there is no scene to write to.
+        year<=0 means no birth date (the event is removed if one exists)."""
+        if not self.scene:
+            _log.warning("saveUserProfile called with no scene")
+            return False
+
+        person = self._primaryPerson()
+        if person is None:
+            person = Person(primary=True)
+            self.scene.addItem(person)
+        elif not person.primary():
+            person.setPrimary(True)
+
+        person.setName(firstName.strip() or None)
+        person.setLastName(lastName.strip() or None)
+
+        birthEvent = person.birthEvent()
+        if year > 0:
+            dateTime = util.Date(year, month, day)
+            if birthEvent is None:
+                # A person's own birth event keys on child(), so the subject is
+                # the child of the event (parents unknown -> no person/spouse).
+                birthEvent = Event(EventKind.Birth, person=person, child=person, dateTime=dateTime)
+                self.scene.addItem(birthEvent)
+            else:
+                birthEvent.setDateTime(dateTime)
+        elif birthEvent is not None:
+            self.scene.removeItem(birthEvent)
+
+        self.saveDiagram()
+        self.markProfilePrompted()
+        self.userProfileChanged.emit()
+        return True
 
     # Model selection
 

--- a/pkdiagram/resources/qml/Personal/AccountDrawer.qml
+++ b/pkdiagram/resources/qml/Personal/AccountDrawer.qml
@@ -45,6 +45,7 @@ Flickable {
         }
 
         Rectangle {
+            objectName: "accountEntry"
             width: parent.width - 32
             height: 60
             radius: 12

--- a/pkdiagram/resources/qml/Personal/PersonalContainer.qml
+++ b/pkdiagram/resources/qml/Personal/PersonalContainer.qml
@@ -1087,7 +1087,10 @@ Page {
                 drawer.close()
                 session.logout()
             }
-            onAccountClicked: console.log("Open account settings")
+            onAccountClicked: {
+                drawer.close()
+                profilePopup.open()
+            }
             onDiagramClicked: function(diagram) {
                 drawer.close()
                 personalApp.loadDiagram(diagram.id)
@@ -1255,6 +1258,48 @@ Page {
         Personal.VoiceSettingsPage {
             anchors.fill: parent
             onBackClicked: voicePopup.close()
+        }
+    }
+
+    // Profile settings popup (FD-321) — opened from the AccountDrawer ACCOUNT entry
+    Popup {
+        id: profilePopup
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: root.width
+        height: root.height
+        modal: true
+        closePolicy: Popup.NoAutoClose
+        padding: 0
+        background: Rectangle { color: "transparent" }
+
+        enter: Transition {
+            NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 150 }
+        }
+        exit: Transition {
+            NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 150 }
+        }
+
+        Personal.ProfileSettingsPage {
+            anchors.fill: parent
+            onBackClicked: profilePopup.close()
+        }
+    }
+
+    // First-launch user-details wizard (FD-321). Shown once when the
+    // profile-prompt pref is unset AND the primary node has no name. Save or
+    // Skip sets the pref so it never reappears.
+    Loader {
+        id: wizardLoader
+        anchors.fill: parent
+        active: session && session.loggedIn && personalApp && personalApp.shouldPromptProfile
+        z: 100
+
+        sourceComponent: Personal.UserDetailsWizard {
+            objectName: "userDetailsWizard"
+            safeAreaTop: root.safeAreaTop
+            safeAreaBottom: root.safeAreaBottom
+            onDone: wizardLoader.active = false
         }
     }
 

--- a/pkdiagram/resources/qml/Personal/ProfileSettingsPage.qml
+++ b/pkdiagram/resources/qml/Personal/ProfileSettingsPage.qml
@@ -1,0 +1,118 @@
+/*
+FD-321 — Settings "Profile" sub-page. Same 56px header + back-chevron chrome as
+VoiceSettingsPage. Hosts UserDetailsForm (non-wizard) pre-populated from the
+primary node, with a Save button enabled only when valid. Reached from the
+AccountDrawer ACCOUNT entry.
+*/
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "." 1.0 as Personal
+
+Page {
+    id: root
+
+    property color headerBg: util.QML_HEADER_BG
+    property color textColor: util.QML_TEXT_COLOR
+    property color secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color accentColor: util.QML_SELECTION_COLOR
+
+    signal backClicked()
+
+    function reload() {
+        formItem.loadProfile(personalApp.userProfile)
+    }
+
+    onVisibleChanged: if (visible) reload()
+    Component.onCompleted: reload()
+
+    background: Rectangle { color: util.QML_WINDOW_BG }
+
+    Rectangle {
+        id: header
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 56
+        color: headerBg
+        z: 10
+
+        Rectangle {
+            anchors.bottom: parent.bottom
+            width: parent.width
+            height: 1
+            color: borderColor
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.leftMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
+            width: 40
+            height: 40
+            radius: 8
+            color: backMouseArea.pressed ? util.QML_ITEM_ALTERNATE_BG : "transparent"
+
+            Text {
+                anchors.centerIn: parent
+                text: "‹"
+                font.pixelSize: 28
+                color: accentColor
+            }
+            MouseArea {
+                id: backMouseArea
+                anchors.fill: parent
+                onClicked: root.backClicked()
+            }
+        }
+
+        Text {
+            anchors.centerIn: parent
+            text: "Profile"
+            font.pixelSize: 17
+            font.bold: true
+            color: textColor
+        }
+
+        Rectangle {
+            objectName: "saveButton"
+            anchors.right: parent.right
+            anchors.rightMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
+            width: saveLabel.width + 16
+            height: 40
+            radius: 8
+            color: "transparent"
+
+            Text {
+                id: saveLabel
+                anchors.centerIn: parent
+                text: "Save"
+                font.pixelSize: 16
+                font.bold: true
+                color: formItem.valid ? accentColor : secondaryText
+            }
+            MouseArea {
+                anchors.fill: parent
+                enabled: formItem.valid
+                onClicked: {
+                    personalApp.saveUserProfile(
+                        formItem.firstName, formItem.lastName,
+                        formItem.birthYear, formItem.birthMonth, formItem.birthDay)
+                    root.backClicked()
+                }
+            }
+        }
+    }
+
+    Personal.UserDetailsForm {
+        id: formItem
+        objectName: "profileForm"
+        wizardMode: false
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+    }
+}

--- a/pkdiagram/resources/qml/Personal/UserDetailsForm.qml
+++ b/pkdiagram/resources/qml/Personal/UserDetailsForm.qml
@@ -1,0 +1,216 @@
+/*
+FD-321 — reusable user-details body. Drives BOTH surfaces:
+  - first-launch wizard (wizardMode: true): Welcome title/subtitle + Get Started + Skip
+  - Settings profile editor (wizardMode: false): plain form, Save lives in the page chrome
+
+firstName/lastName map to the primary Person node's name/lastName; the date maps
+to a Birth EVENT on that node (a fully-empty date is allowed/optional). Exposes
+firstName, lastName, birth Y/M/D, and `valid` for the host's primary button.
+
+The birth date reuses the EventForm idiom: a clickable/focusable DatePickerButtons
+text field plus a DatePicker tumbler, both syncing to a single canonical
+`birthDateTime` (a bare DatePicker can't be clicked into).
+*/
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "../PK" 1.0 as PK
+
+Flickable {
+    id: form
+
+    property bool wizardMode: true
+
+    property color itemBg: util.QML_ITEM_BG
+    property color textColor: util.QML_TEXT_COLOR
+    property color secondaryText: util.QML_INACTIVE_TEXT_COLOR
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color danger: "#FF453A"
+
+    property alias firstName: firstNameField.text
+    property alias lastName: lastNameField.text
+
+    // Canonical birth date; both date controls write to it and sync back from it.
+    property var birthDateTime
+
+    function _dateValid() {
+        return birthDateTime !== undefined && birthDateTime !== null && !isNaN(birthDateTime)
+    }
+
+    // Birth date as separate ints so the controller takes them directly; 0 = unset.
+    readonly property int birthYear: _dateValid() ? birthDateTime.getFullYear() : 0
+    readonly property int birthMonth: _dateValid() ? birthDateTime.getMonth() + 1 : 0
+    readonly property int birthDay: _dateValid() ? birthDateTime.getDate() : 0
+
+    // First name required; date is optional and the controls only ever produce a
+    // real calendar date, so there is no "entered-but-invalid" state.
+    readonly property bool nameValid: firstNameField.text.trim() !== ""
+    readonly property bool valid: nameValid
+
+    property bool firstNameTouched: false
+
+    function loadProfile(profile) {
+        firstNameField.text = profile.firstName || ""
+        lastNameField.text = profile.lastName || ""
+        if (profile.birthYear && profile.birthMonth && profile.birthDay) {
+            form.birthDateTime = new Date(
+                parseInt(profile.birthYear),
+                parseInt(profile.birthMonth) - 1,
+                parseInt(profile.birthDay))
+        } else {
+            form.birthDateTime = undefined
+        }
+        firstNameTouched = false
+    }
+
+    contentHeight: col.height + 40
+    clip: true
+
+    Column {
+        id: col
+        x: 20
+        width: form.width - 40
+        topPadding: form.wizardMode ? 60 : 20
+        spacing: 16
+
+        Text {
+            visible: form.wizardMode
+            text: "Welcome"
+            color: form.textColor
+            font.pixelSize: 30
+            font.bold: true
+        }
+        Text {
+            visible: form.wizardMode
+            width: col.width
+            text: "Tell us who you are so your diagram and the assistant know which person is you."
+            color: form.secondaryText
+            font.pixelSize: 15
+            wrapMode: Text.WordWrap
+            lineHeight: 1.3
+            bottomPadding: 8
+        }
+
+        Text {
+            text: "YOUR NAME"
+            color: form.secondaryText
+            font.pixelSize: 12
+            font.bold: true
+            leftPadding: 4
+        }
+        Rectangle {
+            width: col.width
+            height: 101
+            radius: 12
+            color: form.itemBg
+            border.width: 1
+            border.color: (form.firstNameTouched && !form.nameValid) ? form.danger : form.borderColor
+
+            Column {
+                anchors.fill: parent
+
+                PK.TextField {
+                    id: firstNameField
+                    objectName: "firstNameField"
+                    width: parent.width
+                    height: 50
+                    leftPadding: 14
+                    placeholderText: "First name"
+                    background: Item {}
+                    focus: true
+                    KeyNavigation.tab: lastNameField
+                    onTextChanged: form.firstNameTouched = true
+                    onEditingFinished: form.firstNameTouched = true
+                }
+                Rectangle {
+                    x: 14
+                    width: parent.width - 14
+                    height: 1
+                    color: form.borderColor
+                }
+                PK.TextField {
+                    id: lastNameField
+                    objectName: "lastNameField"
+                    width: parent.width
+                    height: 50
+                    leftPadding: 14
+                    placeholderText: "Last name"
+                    background: Item {}
+                    KeyNavigation.tab: birthDateButtons.firstTabItem
+                    KeyNavigation.backtab: firstNameField
+                }
+            }
+        }
+        Text {
+            visible: form.firstNameTouched && !form.nameValid
+            text: "First name is required."
+            color: form.danger
+            font.pixelSize: 12
+            leftPadding: 4
+        }
+
+        Text {
+            text: "DATE OF BIRTH"
+            color: form.secondaryText
+            font.pixelSize: 12
+            font.bold: true
+            leftPadding: 4
+            topPadding: 8
+        }
+        Rectangle {
+            width: col.width
+            radius: 12
+            color: form.itemBg
+            border.width: 1
+            border.color: form.borderColor
+            height: dateColumn.height + 16
+
+            Column {
+                id: dateColumn
+                x: 14
+                width: parent.width - 28
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 4
+
+                PK.DatePickerButtons {
+                    id: birthDateButtons
+                    objectName: "birthDateButtons"
+                    datePicker: birthDatePicker
+                    hideTime: true
+                    backTabItem: lastNameField
+                    width: parent.width
+                    onDateTimeChanged: form.birthDateTime = dateTime
+                    Connections {
+                        target: form
+                        function onBirthDateTimeChanged() {
+                            if (birthDateButtons.dateTime != form.birthDateTime)
+                                birthDateButtons.dateTime = form.birthDateTime
+                        }
+                    }
+                }
+
+                PK.DatePicker {
+                    id: birthDatePicker
+                    objectName: "birthDatePicker"
+                    // No shouldShow: matches EventForm — the tumbler stays collapsed
+                    // (implicitHeight 0) until birthDateButtons focuses it via updateState().
+                    width: parent.width
+                    onDateTimeChanged: form.birthDateTime = dateTime
+                    Connections {
+                        target: form
+                        function onBirthDateTimeChanged() {
+                            if (birthDatePicker.dateTime != form.birthDateTime)
+                                birthDatePicker.dateTime = form.birthDateTime
+                        }
+                    }
+                }
+            }
+        }
+        Text {
+            text: "Optional — helps the assistant anchor ages and timelines."
+            color: form.secondaryText
+            font.pixelSize: 12
+            leftPadding: 4
+        }
+    }
+}

--- a/pkdiagram/resources/qml/Personal/UserDetailsWizard.qml
+++ b/pkdiagram/resources/qml/Personal/UserDetailsWizard.qml
@@ -1,0 +1,100 @@
+/*
+FD-321 — first-launch wizard surface. Hosts UserDetailsForm (wizardMode) plus
+the bottom action bar (Get Started enabled only when valid, Skip always).
+Saving lands the profile on the primary node and sets the prompt pref; Skip just
+sets the pref. Either way the wizard never reappears.
+*/
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import "." 1.0 as Personal
+
+Rectangle {
+    id: root
+
+    property real safeAreaTop: 0
+    property real safeAreaBottom: 0
+
+    property color borderColor: util.QML_ITEM_BORDER_COLOR
+    property color accent: util.QML_SELECTION_COLOR
+
+    signal done()
+
+    color: util.QML_WINDOW_BG
+
+    Personal.UserDetailsForm {
+        id: formItem
+        objectName: "userDetailsForm"
+        wizardMode: true
+        anchors.top: parent.top
+        anchors.topMargin: root.safeAreaTop
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: bar.top
+    }
+
+    Rectangle {
+        id: bar
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: root.safeAreaBottom
+        width: parent.width
+        height: 120
+        color: util.QML_WINDOW_BG
+
+        Rectangle {
+            anchors.top: parent.top
+            width: parent.width
+            height: 1
+            color: root.borderColor
+        }
+
+        Rectangle {
+            id: getStartedBtn
+            objectName: "getStartedButton"
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: parent.top
+            anchors.topMargin: 16
+            width: parent.width - 40
+            height: 50
+            radius: 14
+            color: formItem.valid ? root.accent : root.borderColor
+            opacity: formItem.valid ? 1.0 : 0.5
+
+            Text {
+                anchors.centerIn: parent
+                text: "Get Started"
+                color: "white"
+                font.pixelSize: 17
+                font.bold: true
+            }
+            MouseArea {
+                anchors.fill: parent
+                enabled: formItem.valid
+                onClicked: {
+                    personalApp.saveUserProfile(
+                        formItem.firstName, formItem.lastName,
+                        formItem.birthYear, formItem.birthMonth, formItem.birthDay)
+                    root.done()
+                }
+            }
+        }
+
+        Text {
+            objectName: "skipButton"
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: getStartedBtn.bottom
+            anchors.topMargin: 14
+            text: "Skip for now"
+            color: root.accent
+            font.pixelSize: 15
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    personalApp.markProfilePrompted()
+                    root.done()
+                }
+            }
+        }
+    }
+}

--- a/pkdiagram/resources/qml/Personal/UserDetailsWizard.qml
+++ b/pkdiagram/resources/qml/Personal/UserDetailsWizard.qml
@@ -31,6 +31,8 @@ Rectangle {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: bar.top
+        // Pre-fill from the account name (own diagram) so the user just confirms it.
+        Component.onCompleted: loadProfile(personalApp.userProfile)
     }
 
     Rectangle {

--- a/pkdiagram/tests/personal/test_userprofile.py
+++ b/pkdiagram/tests/personal/test_userprofile.py
@@ -190,6 +190,33 @@ def test_saveUserProfile_does_not_sync_account_on_client_diagram(
     assert personalApp._primaryPerson().name() == "Client"
 
 
+def test_saveUserProfile_clears_account_last_name(
+    test_user, personalApp: PersonalAppController
+):
+    """Clearing the last name propagates the empty value to the account so node
+    and account do not silently diverge."""
+    _give_diagram(personalApp, test_user)
+    with patch.object(personalApp, "saveDiagram"), patch.object(
+        personalApp.session, "updateName"
+    ) as updateName:
+        personalApp.saveUserProfile("Dana", "", 0, 0, 0)
+    updateName.assert_called_once_with("Dana", "")
+
+
+def test_userProfile_prefill_preserves_existing_birth(
+    test_user, personalApp: PersonalAppController
+):
+    """An unnamed primary that already carries a birth event keeps that date in
+    the account-prefill, so opening then saving the form does not wipe it."""
+    person = personalApp.scene.addItem(Person(primary=True))
+    personalApp.scene.addItem(
+        Event(EventKind.Birth, person=person, child=person, dateTime=util.Date(1990, 5, 20))
+    )
+    profile = personalApp.userProfile
+    assert profile["firstName"] == test_user.first_name
+    assert (profile["birthYear"], profile["birthMonth"], profile["birthDay"]) == ("1990", "5", "20")
+
+
 def test_primaryPerson_falls_back_when_none_marked(
     test_user, personalApp: PersonalAppController
 ):

--- a/pkdiagram/tests/personal/test_userprofile.py
+++ b/pkdiagram/tests/personal/test_userprofile.py
@@ -1,0 +1,265 @@
+"""FD-321 — user-details profile capture/edit on the primary person node."""
+
+import pickle
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from pkdiagram import util
+from pkdiagram.personal import PersonalAppController
+from pkdiagram.scene import Person, Event
+from pkdiagram.server_types import Diagram
+from btcopilot.schema import DiagramData, PDP, asdict, EventKind
+
+pytestmark = [
+    pytest.mark.component("Personal"),
+    pytest.mark.depends_on("Session"),
+]
+
+
+def _give_diagram(personalApp, test_user):
+    """Attach a server Diagram so saveDiagram() has something to write to; its
+    save() is patched off in tests so no network happens."""
+    personalApp._diagram = Diagram(
+        id=test_user.free_diagram_id,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(DiagramData(pdp=PDP()))),
+    )
+
+
+def test_saveUserProfile_lands_name_and_birth_event_on_primary(
+    test_user, personalApp: PersonalAppController
+):
+    _give_diagram(personalApp, test_user)
+    with patch.object(personalApp, "saveDiagram") as save:
+        ok = personalApp.saveUserProfile("Patrick", "Stinson", 1980, 3, 15)
+
+    assert ok is True
+    assert save.call_count == 1
+    person = personalApp._primaryPerson()
+    assert person is not None and person.primary()
+    assert person.name() == "Patrick"
+    assert person.lastName() == "Stinson"
+    birth = person.birthEvent()
+    assert birth is not None
+    assert birth.dateTime().date() == util.Date(1980, 3, 15).date()
+
+
+def test_saveUserProfile_empty_birth_leaves_no_event(
+    test_user, personalApp: PersonalAppController
+):
+    """A fully-empty birth date (year<=0) is allowed: name lands, no Birth event."""
+    _give_diagram(personalApp, test_user)
+    with patch.object(personalApp, "saveDiagram"):
+        personalApp.saveUserProfile("Solo", "", 0, 0, 0)
+
+    person = personalApp._primaryPerson()
+    assert person.name() == "Solo"
+    assert person.lastName() is None
+    assert person.birthEvent() is None
+
+
+def test_saveUserProfile_edits_existing_primary(
+    test_user, personalApp: PersonalAppController
+):
+    """Settings edit: an existing primary person with a birth event is updated
+    in place, not duplicated."""
+    person = personalApp.scene.addItem(Person(name="Old", lastName="Name", primary=True))
+    personalApp.scene.addItem(
+        Event(EventKind.Birth, person=person, child=person, dateTime=util.Date(1970, 1, 1))
+    )
+    _give_diagram(personalApp, test_user)
+
+    with patch.object(personalApp, "saveDiagram"):
+        personalApp.saveUserProfile("New", "Person", 1990, 6, 20)
+
+    people = personalApp.scene.people()
+    assert len(people) == 1
+    assert people[0].name() == "New"
+    assert people[0].lastName() == "Person"
+    assert len([e for e in people[0].events() if e.kind() == EventKind.Birth]) == 1
+    assert people[0].birthEvent().dateTime().date() == util.Date(1990, 6, 20).date()
+
+
+def test_saveUserProfile_clears_birth_event_when_emptied(
+    test_user, personalApp: PersonalAppController
+):
+    person = personalApp.scene.addItem(Person(name="Had", primary=True))
+    personalApp.scene.addItem(
+        Event(EventKind.Birth, person=person, child=person, dateTime=util.Date(1970, 1, 1))
+    )
+    _give_diagram(personalApp, test_user)
+
+    with patch.object(personalApp, "saveDiagram"):
+        personalApp.saveUserProfile("Had", "", 0, 0, 0)
+
+    assert person.birthEvent() is None
+
+
+def test_userProfile_reads_back_primary(
+    test_user, personalApp: PersonalAppController
+):
+    person = personalApp.scene.addItem(
+        Person(name="Read", lastName="Back", primary=True)
+    )
+    personalApp.scene.addItem(
+        Event(EventKind.Birth, person=person, child=person, dateTime=util.Date(1985, 12, 3))
+    )
+
+    profile = personalApp.userProfile
+    assert profile["firstName"] == "Read"
+    assert profile["lastName"] == "Back"
+    assert profile["birthYear"] == "1985"
+    assert profile["birthMonth"] == "12"
+    assert profile["birthDay"] == "3"
+
+
+def test_userProfile_empty_when_no_people(
+    test_user, personalApp: PersonalAppController
+):
+    profile = personalApp.userProfile
+    assert profile == {
+        "firstName": "",
+        "lastName": "",
+        "birthYear": "",
+        "birthMonth": "",
+        "birthDay": "",
+    }
+
+
+def test_primaryPerson_falls_back_when_none_marked(
+    test_user, personalApp: PersonalAppController
+):
+    """C6: a pre-existing diagram with no node marked primary is still editable —
+    fall back to the lowest-id person deterministically."""
+    p1 = personalApp.scene.addItem(Person(name="First"))
+    p2 = personalApp.scene.addItem(Person(name="Second"))
+    assert p1.id < p2.id
+
+    assert personalApp._primaryPerson() is p1
+
+
+def test_primaryPerson_prefers_marked_over_id(
+    test_user, personalApp: PersonalAppController
+):
+    personalApp.scene.addItem(Person(name="Lowest"))
+    p2 = personalApp.scene.addItem(Person(name="Marked", primary=True))
+
+    assert personalApp._primaryPerson() is p2
+
+
+def test_shouldPromptProfile_true_when_unset_and_no_name(
+    test_user, personalApp: PersonalAppController
+):
+    personalApp.appConfig.delete("personalProfilePrompted")
+    assert personalApp.shouldPromptProfile is True
+
+
+def test_shouldPromptProfile_false_when_primary_named(
+    test_user, personalApp: PersonalAppController
+):
+    personalApp.appConfig.delete("personalProfilePrompted")
+    personalApp.scene.addItem(Person(name="Named", primary=True))
+    assert personalApp.shouldPromptProfile is False
+
+
+def test_markProfilePrompted_suppresses_wizard(
+    test_user, personalApp: PersonalAppController
+):
+    """Skip path: setting the pref prevents the wizard even with a nameless
+    diagram."""
+    personalApp.appConfig.delete("personalProfilePrompted")
+    assert personalApp.shouldPromptProfile is True
+
+    with patch.object(personalApp.appConfig, "write"):
+        personalApp.markProfilePrompted()
+
+    assert personalApp.shouldPromptProfile is False
+
+
+def test_saveUserProfile_sets_prompted_pref(
+    test_user, personalApp: PersonalAppController
+):
+    """Completing the wizard via save also stops it reappearing."""
+    personalApp.appConfig.delete("personalProfilePrompted")
+    _give_diagram(personalApp, test_user)
+
+    with (
+        patch.object(personalApp, "saveDiagram"),
+        patch.object(personalApp.appConfig, "write"),
+    ):
+        personalApp.saveUserProfile("X", "", 0, 0, 0)
+
+    assert personalApp.shouldPromptProfile is False
+
+
+def test_saveUserProfile_no_scene_returns_false(
+    test_user, personalApp: PersonalAppController
+):
+    personalApp.scene = None
+    assert personalApp.saveUserProfile("X", "", 0, 0, 0) is False
+
+
+def _findChild(root, objectName):
+    from pkdiagram.pyqt import QQuickItem
+
+    for child in root.findChildren(QQuickItem):
+        if child.objectName() == objectName:
+            return child
+    return None
+
+
+def test_userDetailsForm_validates_on_first_name(qApp, test_session):
+    """The reusable form (mounted in the wizard inside PersonalContainer) gates
+    `valid` on a non-blank first name, which drives the Get Started/Save button.
+    Loaded through the app's own engine so lazy QML binding errors surface."""
+    from pkdiagram.pyqt import QQmlApplicationEngine, QApplication
+    from pkdiagram.scene import Scene
+
+    app = PersonalAppController()
+    engine = QQmlApplicationEngine()
+    errors = []
+    engine.warnings.connect(lambda errs: errors.extend(errs))
+    engine.addImportPath("resources:")
+    app.init(engine)
+    app.session.init(
+        sessionData=test_session.account_editor_dict(), syncWithServer=False
+    )
+    app.setScene(Scene())
+    engine.load("resources:qml/PersonalApplication.qml")
+    QApplication.processEvents()
+    util.waitALittle()
+    assert not errors, [e.toString() for e in errors]
+
+    root = engine.rootObjects()[0]
+    # Force the wizard active so its UserDetailsForm instantiates (lazy Loader).
+    app.appConfig.delete("personalProfilePrompted")
+    app.userProfileChanged.emit()
+    QApplication.processEvents()
+    util.waitALittle()
+
+    form = _findChild(root, "userDetailsForm")
+    assert form is not None, "wizard form did not mount"
+    assert form.property("valid") is False
+    form.setProperty("firstName", "Patrick")
+    assert form.property("valid") is True
+
+    # Empty birth date -> 0 (optional, allowed).
+    assert form.property("birthYear") == 0
+    assert form.property("birthMonth") == 0
+    assert form.property("birthDay") == 0
+
+    # Setting the canonical birthDateTime flows to the derived Y/M/D ints the
+    # controller consumes (reuses the EventForm date idiom).
+    from PyQt5.QtCore import QDateTime, QDate
+
+    form.setProperty("birthDateTime", QDateTime(QDate(1980, 3, 15)))
+    QApplication.processEvents()
+    assert form.property("birthYear") == 1980
+    assert form.property("birthMonth") == 3
+    assert form.property("birthDay") == 15
+
+    engine.clearComponentCache()

--- a/pkdiagram/tests/personal/test_userprofile.py
+++ b/pkdiagram/tests/personal/test_userprofile.py
@@ -18,6 +18,28 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _stub_account_sync(monkeypatch):
+    """The account write-back (Session.updateName) hits the server. Stub it by
+    default so node-behavior tests stay offline; the dedicated link tests patch
+    it on the instance to assert the call."""
+    from pkdiagram.app.session import Session
+
+    monkeypatch.setattr(Session, "updateName", lambda self, f, l: True)
+
+
+def _give_client_diagram(personalApp, test_user):
+    """A diagram that is NOT the user's free diagram — e.g. a clinician's client
+    file. The account name must never be read from or written to here."""
+    personalApp._diagram = Diagram(
+        id=(test_user.free_diagram_id or 0) + 1000,
+        user_id=test_user.id,
+        access_rights=[],
+        created_at=datetime.utcnow(),
+        data=pickle.dumps(asdict(DiagramData(pdp=PDP()))),
+    )
+
+
 def _give_diagram(personalApp, test_user):
     """Attach a server Diagram so saveDiagram() has something to write to; its
     save() is patched off in tests so no network happens."""
@@ -117,9 +139,22 @@ def test_userProfile_reads_back_primary(
     assert profile["birthDay"] == "3"
 
 
-def test_userProfile_empty_when_no_people(
+def test_userProfile_prefills_account_name_on_own_diagram(
     test_user, personalApp: PersonalAppController
 ):
+    """On the user's own (free) diagram with an unnamed primary, the profile
+    pre-fills from the account name set at signup."""
+    profile = personalApp.userProfile
+    assert profile["firstName"] == test_user.first_name
+    assert profile["lastName"] == test_user.last_name
+    assert profile["birthYear"] == ""
+
+
+def test_userProfile_does_not_prefill_on_client_diagram(
+    test_user, personalApp: PersonalAppController
+):
+    """A client file (not the free diagram) never pre-fills from the account."""
+    _give_client_diagram(personalApp, test_user)
     profile = personalApp.userProfile
     assert profile == {
         "firstName": "",
@@ -128,6 +163,31 @@ def test_userProfile_empty_when_no_people(
         "birthMonth": "",
         "birthDay": "",
     }
+
+
+def test_saveUserProfile_syncs_account_name_on_own_diagram(
+    test_user, personalApp: PersonalAppController
+):
+    """Saving on the free diagram writes the name back to the account."""
+    _give_diagram(personalApp, test_user)
+    with patch.object(personalApp, "saveDiagram"), patch.object(
+        personalApp.session, "updateName"
+    ) as updateName:
+        personalApp.saveUserProfile("Dana", "Reed", 0, 0, 0)
+    updateName.assert_called_once_with("Dana", "Reed")
+
+
+def test_saveUserProfile_does_not_sync_account_on_client_diagram(
+    test_user, personalApp: PersonalAppController
+):
+    """Saving on a client file must NOT touch the account name."""
+    _give_client_diagram(personalApp, test_user)
+    with patch.object(personalApp, "saveDiagram"), patch.object(
+        personalApp.session, "updateName"
+    ) as updateName:
+        personalApp.saveUserProfile("Client", "Person", 0, 0, 0)
+    updateName.assert_not_called()
+    assert personalApp._primaryPerson().name() == "Client"
 
 
 def test_primaryPerson_falls_back_when_none_marked(
@@ -243,6 +303,10 @@ def test_userDetailsForm_validates_on_first_name(qApp, test_session):
 
     form = _findChild(root, "userDetailsForm")
     assert form is not None, "wizard form did not mount"
+    # The wizard pre-fills the first name from the account; clear it to exercise
+    # the empty-name gate.
+    assert form.property("firstName") != ""
+    form.setProperty("firstName", "")
     assert form.property("valid") is False
     form.setProperty("firstName", "Patrick")
     assert form.property("valid") is True


### PR DESCRIPTION
Frontend half of FD-321 (Personal app user profile). First-launch setup wizard + Settings profile editor sharing one reusable `UserDetailsForm`. Pairs with btcopilot#127.

## Changes
- `UserDetailsForm.qml` (reusable), `UserDetailsWizard.qml` (first-launch), `ProfileSettingsPage.qml` (Settings).
- Captures name + birth date; lands name on the user's own (primary) person node and birth date as a Birth event; skippable wizard that never re-nags; persists via the normal save path.
- Birth date reuses the EventForm `PK.DatePickerButtons`+`PK.DatePicker` control with First→Last→date tab order and collapse-until-focused tumbler.
- Controller: `shouldPromptProfile`, `userProfile`, `saveUserProfile`, deterministic primary fallback.
- Test handle (objectName) on the account drawer entry; ui-planner spec + prototypes.

## Verified on the live Personal app (offscreen bridge, isolated server)
- C1 wizard appears + unloads; C2 skip leaves app usable; C3 empty-name gate; C4 save lands name+birth and persists across relaunch (no re-nag); C5 Settings shows + edits + persists.
- C6 partial (no-crash + settable shown; fallback unit-tested). C7/C12 pending.
- Unit: `test_userprofile` (14) + personal suite 173 green.

See `doc/workstreams/fd-321.json` (in btcopilot PR) for full criteria status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)